### PR TITLE
[2.1 branch] WFLY-6678 - Don't allow multiple instances of client interceptors to be registered with same priority

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -527,7 +527,11 @@ public final class EJBClientContext extends Attachable implements Closeable {
         EJBClientInterceptor.Registration[] oldRegistrations, newRegistrations;
         do {
             oldRegistrations = registrations;
-            for (EJBClientInterceptor.Registration oldRegistration : oldRegistrations) {
+            for (final EJBClientInterceptor.Registration oldRegistration : oldRegistrations) {
+                // check if more than one interceptor instance is being registered with same priority (which we shouldn't allow)
+                if (oldRegistration.getPriority() == priority && oldRegistration.getInterceptor() != clientInterceptor) {
+                    throw Logs.MAIN.duplicatePriorityEJBClientInterceptorRegistration(clientInterceptor, priority);
+                }
                 if (oldRegistration.getInterceptor() == clientInterceptor) {
                     if (oldRegistration.compareTo(newRegistration) == 0) {
                         // This means that a client interceptor which has already been added to this context,

--- a/src/main/java/org/jboss/ejb/client/EJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInterceptor.java
@@ -74,6 +74,10 @@ public interface EJBClientInterceptor {
             return interceptor;
         }
 
+        int getPriority() {
+            return this.priority;
+        }
+
         public int compareTo(final Registration o) {
             return Integer.signum(priority - o.priority);
         }

--- a/src/main/java/org/jboss/ejb/client/Logs.java
+++ b/src/main/java/org/jboss/ejb/client/Logs.java
@@ -265,6 +265,9 @@ public interface Logs extends BasicLogger {
     @Message(id = 61, value = "Cannot send a transaction recovery message to the server since the protocol version of EJBReceiver %s doesn't support it")
     void transactionRecoveryMessageNotSupported(EJBReceiver receiver);
 
+    @Message(id = 62, value = "Cannot register EJB client interceptor %s since a different interceptor is already registered with the same priority %d" )
+    IllegalArgumentException duplicatePriorityEJBClientInterceptorRegistration(final EJBClientInterceptor interceptor, final int priority);
+
     // Proxy API errors
 
     @Message(id = 100, value = "Object '%s' is not a valid proxy object")

--- a/src/test/java/org/jboss/ejb/client/test/interceptor/ClientInterceptorRegistrationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/interceptor/ClientInterceptorRegistrationTestCase.java
@@ -1,0 +1,50 @@
+package org.jboss.ejb.client.test.interceptor;
+
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests registration of {@link EJBClientInterceptor}(s) in a {@link EJBClientContext}
+ *
+ * @author Jaikiran Pai
+ */
+public class ClientInterceptorRegistrationTestCase {
+
+    /**
+     * Tests that multiple interceptor instances cannot be registered with the same priority
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDuplicatePriorityRegistration() throws Exception {
+        final int priority = 0x99999;
+        final EJBClientContext clientContext = EJBClientContext.create();
+        final PassThroughInterceptor firstInstanceOfInterceptor = new PassThroughInterceptor();
+        clientContext.registerInterceptor(priority, firstInstanceOfInterceptor);
+        // try to register again at the same priority, a new instance. This should fail
+        try {
+            clientContext.registerInterceptor(priority, new PassThroughInterceptor());
+            Assert.fail("Registering different instance of client interceptor at the same priority (" + priority + ") was expected to fail, but it didn't");
+        } catch (IllegalArgumentException iae) {
+            // expected
+        }
+        // now try to register the same instance of the interceptor again at the same priority. This should pass
+        clientContext.registerInterceptor(priority, firstInstanceOfInterceptor);
+    }
+
+    private class PassThroughInterceptor implements EJBClientInterceptor {
+
+        @Override
+        public void handleInvocation(final EJBClientInvocationContext context) throws Exception {
+            context.sendRequest();
+        }
+
+        @Override
+        public Object handleInvocationResult(final EJBClientInvocationContext context) throws Exception {
+            return context.getResult();
+        }
+    }
+}


### PR DESCRIPTION
I think, in general, we shouldn't allow registering multiple instances of an interceptor at the same priority. This came into question in the context of https://issues.jboss.org/browse/WFLY-6678?focusedCommentId=13251496&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13251496
