### PR TITLE
EJBCLIENT-243 Make sure only the first result is taken into account.

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -637,7 +637,7 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
     void resultReady(EJBReceiverInvocationContext.ResultProducer resultProducer) {
         Assert.checkNotNullParam("resultProducer", resultProducer);
         synchronized (lock) {
-            if (state.isWaiting()) {
+            if (state.isWaiting() && this.resultProducer == null) {
                 this.resultProducer = resultProducer;
                 if (state == State.WAITING) {
                     transition(State.READY);
@@ -649,7 +649,6 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
         }
         // for whatever reason, we don't care
         resultProducer.discardResult();
-        return;
     }
 
     /**


### PR DESCRIPTION
When proceedAsynchronously() the state can still be SENT, and then
if the async method throws an exception from another thread the result
producer can be changed to the exception producer, resulting in incorrect
behaviour