### PR TITLE
[EJBCLIENT-249] Also check the blacklist when attempting to set a destination using a URIAffinity

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -202,13 +202,19 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         FilterSpec filterSpec, fallbackFilterSpec;
 
         if (affinity instanceof URIAffinity || affinity == Affinity.LOCAL) {
-            // Simple; just set a fixed destination
-            context.setDestination(affinity.getUri());
-            context.setTargetAffinity(affinity);
+            final Set<URI> blacklist = context.getAttachment(BL_KEY);
+            if (blacklist == null || ! blacklist.contains(affinity.getUri())) {
+                // Simple; just set a fixed destination
+                context.setDestination(affinity.getUri());
+                context.setTargetAffinity(affinity);
+            }
             return null;
         } else if (affinity == Affinity.NONE && weakAffinity instanceof URIAffinity) {
-            context.setDestination(weakAffinity.getUri());
-            context.setTargetAffinity(weakAffinity);
+            final Set<URI> blacklist = context.getAttachment(BL_KEY);
+            if (blacklist == null || ! blacklist.contains(weakAffinity.getUri())) {
+                context.setDestination(weakAffinity.getUri());
+                context.setTargetAffinity(weakAffinity);
+            }
             return null;
         } else if (affinity == Affinity.NONE && weakAffinity instanceof NodeAffinity) {
             filterSpec = FilterSpec.equal(FILTER_ATTR_NODE, ((NodeAffinity) weakAffinity).getNodeName());


### PR DESCRIPTION
Currently, if an EJB is called using an invalid username/password combination in a non-clustered environment, the authentication gets re-attempted 8 times and fails each time, resulting in the stack trace described in [EJBCLIENT-249](https://issues.jboss.org/browse/EJBCLIENT-249). This PR updates `DiscoveryEJBClientInterceptor#executeDiscovery` to also check the blacklist when setting a destination using a `URIAffinity`.

https://issues.jboss.org/browse/EJBCLIENT-249
https://issues.jboss.org/browse/JBEAP-12006