### PR TITLE
[EJBCLIENT-250] Invocation timeout not being processed correctly.

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -868,7 +868,8 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                                         intr = true;
                                     }
                                 } else {
-                                    long remaining = max(0L, timeout - max(0L, System.nanoTime() - startTime));
+                                    // timeout in ms, elapsed time in nanosecs
+                                    long remaining = max(0L, timeout * 1_000_000L - max(0L, System.nanoTime() - startTime));
                                     if (remaining == 0L) {
                                         // timed out
                                         timedOut = true;
@@ -1069,7 +1070,8 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
             final long handlerInvTimeout = invocationHandler.getInvocationTimeout();
             final long invocationTimeout = handlerInvTimeout != -1 ? handlerInvTimeout : getClientContext().getInvocationTimeout();
             final long ourStart = System.nanoTime();
-            if (unit.convert(max(0L, invocationTimeout - max(0L, ourStart - startTime)), TimeUnit.NANOSECONDS) <= timeout) {
+            // invocationTimeout in ms, elapsed time in nanosecs
+            if (unit.convert(max(0L, invocationTimeout * 1_000_000L - max(0L, ourStart - startTime)), TimeUnit.NANOSECONDS) <= timeout) {
                 // the invocation will expire before we finish
                 return get();
             }

--- a/src/main/resources/schema/wildfly-client-ejb_3_0.xsd
+++ b/src/main/resources/schema/wildfly-client-ejb_3_0.xsd
@@ -33,9 +33,14 @@
 
     <xsd:complexType name="ejb-client-type">
         <xsd:all minOccurs="1" maxOccurs="1">
+            <xsd:element name="invocation-timeout" type="invocation-timeout-type" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="global-interceptors" type="interceptors-type" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="connections" type="connections-type" minOccurs="0" maxOccurs="1"/>
         </xsd:all>
+    </xsd:complexType>
+
+    <xsd:complexType name="invocation-timeout-type">
+        <xsd:attribute name="seconds" type="xsd:integer" use="required"/>
     </xsd:complexType>
 
     <!-- Interceptors -->

--- a/src/test/java/org/jboss/ejb/client/test/WildflyClientXMLTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/WildflyClientXMLTestCase.java
@@ -1,0 +1,40 @@
+package org.jboss.ejb.client.test;
+
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Tests some basic features of wildfly-client.xml processing
+ *
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class WildflyClientXMLTestCase {
+
+    private static final Logger logger = Logger.getLogger(WildflyClientXMLTestCase.class);
+    private static final String CONFIGURATION_FILE_SYSTEM_PROPERTY_NAME = "wildfly.config.url";
+    private static final String CONFIGURATION_FILE = "wildfly-client.xml";
+    private static final long INVOCATION_TIMEOUT = 10*1000;
+
+    /**
+     * Do any general setup here
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // make sure the desired configuration file is picked up
+        ClassLoader cl = WildflyClientXMLTestCase.class.getClassLoader();
+        File file = new File(cl.getResource(CONFIGURATION_FILE).getFile());
+        System.setProperty(CONFIGURATION_FILE_SYSTEM_PROPERTY_NAME,file.getAbsolutePath());
+    }
+
+    @Test
+    public void testInvocationTimeout() {
+        EJBClientContext clientContext = EJBClientContext.getCurrent();
+        Assert.assertEquals("Got an unexpected timeout value", INVOCATION_TIMEOUT, clientContext.getInvocationTimeout());
+    }
+}

--- a/src/test/resources/wildfly-client.xml
+++ b/src/test/resources/wildfly-client.xml
@@ -14,4 +14,9 @@
             </configuration>
         </authentication-configurations>
     </authentication-client>
+    <jboss-ejb-client xmlns="urn:jboss:wildfly-client-ejb:3.0">
+        <invocation-timeout seconds="10"/>
+        <global-interceptors/>
+        <connections/>
+    </jboss-ejb-client>
 </configuration>


### PR DESCRIPTION
This PR does the following:
- adjusts a calculation for computing the time remaining in an invocation when an invocation timeout is specified
- adds in a means for specifying invocation timeout in <jboss-ejb-client> in wildfly-client.xml

See https://issues.jboss.org/browse/EJBCLIENT-250