### PR TITLE
[EJBCLIENT-162] EJB client unnecessary mark a channel/connection as b…

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -29,9 +29,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.rmi.RemoteException;
 import java.rmi.UnmarshalException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -197,7 +199,7 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
 
         try {
             // send the request
-            sendRequestWithPossibleRetries(invocationContext, true);
+            sendRequestWithPossibleRetries(invocationContext, true, new ArrayList<String>());
 
             if (!async) {
                 // wait for invocation to complete
@@ -248,7 +250,7 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
      * @param firstAttempt            True if this is a first attempt at sending the request, false if this is a retry
      * @throws Exception
      */
-    private static void sendRequestWithPossibleRetries(final EJBClientInvocationContext clientInvocationContext, final boolean firstAttempt) throws Exception {
+    private static void sendRequestWithPossibleRetries(final EJBClientInvocationContext clientInvocationContext, final boolean firstAttempt, final List<String> failedNodes) throws Exception {
         try {
             // this is the first attempt so use the sendRequest API
             if (firstAttempt) {
@@ -270,12 +272,11 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
                 }
             }
             final String failedNodeName = rsfe.getFailedNodeName();
-            if (failedNodeName != null) {
+            if (failedNodeName != null && !failedNodes.contains(failedNodeName)) {
+                failedNodes.add(failedNodeName);
                 Logs.MAIN.debugf(rsfe, "Retrying invocation %s which failed on node: %s due to:", clientInvocationContext, failedNodeName);
-                // exclude this failed node, during the retry
-                clientInvocationContext.markNodeAsExcluded(failedNodeName);
                 // retry
-                sendRequestWithPossibleRetries(clientInvocationContext, false);
+                sendRequestWithPossibleRetries(clientInvocationContext, false, failedNodes);
             } else {
                 throw rsfe;
             }


### PR DESCRIPTION
…roken if can't read a message

Do not exclude the node when failed to send invocation

Jira: https://issues.jboss.org/browse/EJBCLIENT-162
The merged PR to `2.1` branch: #265
PR to `3.x` branch: https://github.com/wildfly/jboss-ejb-client/pull/295
This is the PR cherry-picked to `2.x` branch