### PR TITLE
EJBCLIENT-254 client fails on Xbootclasspath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,10 @@
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>
         <version.org.wildfly.client-config>1.0.0.Final</version.org.wildfly.client-config>
         <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.naming.client>1.0.2.Final-SNAPSHOT</version.org.wildfly.naming.client>
+        <version.org.wildfly.naming.client>1.0.2.Final</version.org.wildfly.naming.client>
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.security.elytron>1.1.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.transaction-client>1.0.1.Final-SNAPSHOT</version.org.wildfly.transaction-client>
+        <version.org.wildfly.transaction-client>1.0.1.Final</version.org.wildfly.transaction-client>
 
         <version.org.jboss.bridger>1.4.Final</version.org.jboss.bridger>
     </properties>


### PR DESCRIPTION
DO NOT MERGE YET (Needs update after merged component updates)

https://issues.jboss.org/browse/EJBCLIENT-254
https://issues.jboss.org/browse/JBEAP-12752

Components:

[JBMAR-210](https://issues.jboss.org/browse/JBMAR-210) - https://github.com/jboss-remoting/jboss-marshalling/pull/70
[ELY-1337](https://issues.jboss.org/browse/ELY-1337) - https://github.com/wildfly-security/wildfly-elytron/pull/954

Normal test run does not include bootclasspath runner.

To test with both standard and bootclasspath:
mvn -Dtest-bootclasspath test



Supersedes #300 