### PR TITLE
EJBCLIENT-254 client fails on Xbootclasspath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <!-- 2.1.x also work on JDK9-->
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager>2.0.7.Final</version.org.jboss.logmanager>
-        <version.org.jboss.marshalling>2.0.0.Final</version.org.jboss.marshalling>
+        <version.org.jboss.marshalling>2.0.1.Final</version.org.jboss.marshalling>
         <version.org.jboss.modules>1.6.0.Final</version.org.jboss.modules>
         <version.org.jboss.remoting>5.0.0.Final</version.org.jboss.remoting>
         <version.org.jboss.spec.javax.ejb>1.0.0.Final</version.org.jboss.spec.javax.ejb>
@@ -278,4 +278,37 @@
         <developerConnection>scm:git:git@github.com:jbossas/jboss-ejb-client.git</developerConnection>
         <url>https://github.com/jbossas/jboss-ejb-client</url>
     </scm>
+    <profiles>
+        <profile>
+            <id>test-bootclasspath</id>
+            <activation>
+                <property>
+                    <name>test-bootclasspath</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>java</executable>
+                            <longClasspath>false</longClasspath>
+                            <classpathScope>test</classpathScope>
+                            <commandlineArgs>-Xbootclasspath/a:%classpath org.jboss.ejb.client.test.ManualTestRunner "Boot ClassPath Testing"</commandlineArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/src/main/java/org/jboss/ejb/client/legacy/JBossEJBProperties.java
+++ b/src/main/java/org/jboss/ejb/client/legacy/JBossEJBProperties.java
@@ -414,6 +414,10 @@ public final class JBossEJBProperties implements Contextual<JBossEJBProperties> 
         if (stream == null) {
             return null;
         }
+        return fromResource(fileName, stream);
+    }
+
+    private static JBossEJBProperties fromResource(String fileName, InputStream stream) throws IOException {
         try (InputStream inputStream = stream) {
             try (BufferedInputStream bis = new BufferedInputStream(inputStream)) {
                 try (InputStreamReader reader = new InputStreamReader(bis, StandardCharsets.UTF_8)) {
@@ -444,6 +448,9 @@ public final class JBossEJBProperties implements Contextual<JBossEJBProperties> 
     }
 
     public static JBossEJBProperties fromClassPath(final ClassLoader classLoader, final String pathName) throws IOException {
+        if (classLoader == null) {
+            return fromResource(pathName, ClassLoader.getSystemResourceAsStream(pathName));
+        }
         return fromResource(pathName, ClassLoader::getResourceAsStream, classLoader, pathName);
     }
 

--- a/src/test/java/org/jboss/ejb/client/test/ClassCallback.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClassCallback.java
@@ -1,0 +1,15 @@
+package org.jboss.ejb.client.test;
+
+public class ClassCallback {
+    private static volatile Runnable beforeClassCallback;
+
+    public static void beforeClassCallback() {
+        if (beforeClassCallback != null) {
+            beforeClassCallback.run();
+        }
+    }
+
+    public static void setBeforeClassCallback(Runnable beforeClassCallback) {
+        ClassCallback.beforeClassCallback = beforeClassCallback;
+    }
+}

--- a/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
@@ -36,8 +36,12 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.wildfly.common.context.ContextManager;
+import org.wildfly.common.context.Contextual;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 
@@ -83,6 +87,9 @@ public class ClusteredInvocationTestCase {
         // trigger the static init of the correct properties file - this also depends on running in forkMode=always
         JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
         JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
+
+        // Launch callback if needed
+        ClassCallback.beforeClassCallback();
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/test/JBossEJBPropertiesTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/JBossEJBPropertiesTestCase.java
@@ -245,4 +245,9 @@ public class JBossEJBPropertiesTestCase {
     public static void afterClass() {
     }
 
+    public static void main(String[] args) throws Exception {
+        JBossEJBPropertiesTestCase props = new JBossEJBPropertiesTestCase();
+        props.testLegacyProperties();
+    }
+
 }

--- a/src/test/java/org/jboss/ejb/client/test/ManualTestRunner.java
+++ b/src/test/java/org/jboss/ejb/client/test/ManualTestRunner.java
@@ -1,0 +1,57 @@
+package org.jboss.ejb.client.test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.jboss.ejb.client.serialization.ProxySerializationTestCase;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+// Manually launches EJB tests (e.g. for Xbootclasspath testing)
+public class ManualTestRunner {
+    public static void main(String[] args) throws Exception {
+        String summary = args.length > 0 ? args[0] : null;
+        if (summary == null || summary.length() == 0) {
+            summary = "Manual Test Run";
+        }
+        System.out.println("===========================");
+        System.out.printf(" %s \n", summary);
+        System.out.println("===========================");
+
+        ClassCallback.setBeforeClassCallback(ManualTestRunner::reloadConfiguration);
+
+        Result result = JUnitCore.runClasses(JBossEJBPropertiesTestCase.class, ClusteredInvocationTestCase.class, SimpleInvocationTestCase.class, ProxySerializationTestCase.class, WildflyClientXMLTestCase.class);
+
+        System.out.println("Failed: " + result.getFailureCount() + " Ignored: " + result.getIgnoreCount() +
+                           " Succeeded: " + (result.getRunCount() - result.getFailureCount() - result.getIgnoreCount()));
+        for (Failure failure: result.getFailures()) {
+            System.out.println(failure.getDescription());
+            System.out.println(failure.getTrace());
+        }
+
+        System.exit(result.wasSuccessful() ? 0 : 1);
+    }
+
+     private static void reloadConfiguration()  {
+        try {
+            // Force reconfiguration so that one test class doesn't pollute the other 
+            // (since we are running them all in one JVM)
+            Class<?> clazz = Class.forName("org.jboss.ejb.client.ConfigurationBasedEJBClientContextSelector");
+            Method init = clazz.getDeclaredMethod("loadConfiguration");
+            init.setAccessible(true);
+            Object o = init.invoke(null);
+            Field field = clazz.getDeclaredField("configuredContext");
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+            field.setAccessible(true);
+            field.set(null, o);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+     }
+}
+

--- a/src/test/java/org/jboss/ejb/client/test/SimpleInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/SimpleInvocationTestCase.java
@@ -33,7 +33,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.wildfly.common.context.ContextManager;
+import org.wildfly.common.context.Contextual;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -58,6 +63,7 @@ public class SimpleInvocationTestCase {
 
     private static final String SERVER_NAME = "test-server";
 
+
     /**
      * Do any general setup here
      * @throws Exception
@@ -67,6 +73,9 @@ public class SimpleInvocationTestCase {
         // trigger the static init of the correct proeprties file - this also depends on running in forkMode=always
         JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
         JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
+
+        // Launch callback if needed
+        ClassCallback.beforeClassCallback();
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/test/WildflyClientXMLTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/WildflyClientXMLTestCase.java
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.net.URL;
 
 /**
  * Tests some basic features of wildfly-client.xml processing
@@ -45,8 +46,10 @@ public class WildflyClientXMLTestCase {
     public static void beforeClass() throws Exception {
         // make sure the desired configuration file is picked up
         ClassLoader cl = WildflyClientXMLTestCase.class.getClassLoader();
-        File file = new File(cl.getResource(CONFIGURATION_FILE).getFile());
+        URL resource = cl != null ? cl.getResource(CONFIGURATION_FILE) : ClassLoader.getSystemResource(CONFIGURATION_FILE);
+        File file = new File(resource.getFile());
         System.setProperty(CONFIGURATION_FILE_SYSTEM_PROPERTY_NAME,file.getAbsolutePath());
+        ClassCallback.beforeClassCallback();
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-254
https://issues.jboss.org/browse/JBEAP-12752

Components:

JBMAR-210 - jboss-remoting/jboss-marshalling#70
ELY-1337 - wildfly-security/wildfly-elytron#954

Normal test run does not include bootclasspath runner.

To test with both standard and bootclasspath:
mvn -Dtest-bootclasspath test

Supersedes #300