### PR TITLE
Fixes for EJBCLIENT-285 and EJBCLIENT-284

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
         <version.org.wildfly.naming.client>1.0.4.Final</version.org.wildfly.naming.client>
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.security.elytron>1.1.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.5.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.transaction-client>1.0.2.Final</version.org.wildfly.transaction-client>
 
         <version.org.jboss.bridger>1.4.Final</version.org.jboss.bridger>

--- a/src/main/java/org/jboss/ejb/_private/Logs.java
+++ b/src/main/java/org/jboss/ejb/_private/Logs.java
@@ -329,6 +329,9 @@ public interface Logs extends BasicLogger {
     @Message(id = 80, value = "Request not sent")
     IllegalStateException requestNotSent();
 
+    @Message(id = 81, value = "Failed to instantiate cluster node selector class \"%s\"")
+    IllegalArgumentException cannotInstantiateClustertNodeSelector(String name, @Cause ReflectiveOperationException e);
+
     // Proxy API errors
 
     @Message(id = 100, value = "Object '%s' is not a valid proxy object")

--- a/src/main/java/org/jboss/ejb/_private/Logs.java
+++ b/src/main/java/org/jboss/ejb/_private/Logs.java
@@ -416,6 +416,9 @@ public interface Logs extends BasicLogger {
     @Message(id = 509, value = "Unexpected exception processing EJB request")
     void unexpectedException(@Cause Throwable t);
 
+    @Message(id = 510, value = "Failed to configure SSL context")
+    IOException failedToConfigureSslContext(@Cause Throwable cause);
+
     // Remote messages; no ID for brevity but should be translated
 
     @Message(value = "No such EJB: %s")

--- a/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
@@ -23,8 +23,6 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.transaction.Transaction;
-
 import org.wildfly.common.Assert;
 import org.wildfly.transaction.client.AbstractTransaction;
 
@@ -41,6 +39,21 @@ public abstract class AbstractInvocationContext extends Attachable {
     private Affinity weakAffinity = Affinity.NONE;
     private URI destination;
     private Affinity targetAffinity;
+    private String initialCluster;
+
+    /**
+     * Gets the initial cluster assignment by discovery, if any
+     *
+     * @return the initial cluster if assigned
+     */
+    public String getInitialCluster() {
+        return initialCluster;
+    }
+
+    void setInitialCluster(String initialCluster) {
+        this.initialCluster = initialCluster;
+    }
+
     private Map<String, Object> contextData;
     private AbstractTransaction transaction;
 

--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -33,11 +33,13 @@ import java.net.URI;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 import javax.ejb.NoSuchEJBException;
@@ -336,22 +338,25 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         if (fallbackFilterSpec != null) {
             assert context.getLocator().getAffinity() instanceof ClusterAffinity;
             Logs.INVOCATION.tracef("Performed first-match discovery, no match, falling back to cluster discovery");
-            final List<Throwable> problems2 = doClusterDiscovery(context, fallbackFilterSpec);
-            if (problems2.isEmpty()) {
-                return problems;
-            } else if (problems.isEmpty()) {
-                return problems2;
-            } else {
-                final ArrayList<Throwable> problems3 = new ArrayList<>(problems.size() + problems2.size());
-                problems3.addAll(problems);
-                problems3.addAll(problems2);
-                return problems3;
-            }
+            return merge(problems, doClusterDiscovery(context, fallbackFilterSpec));
         } else {
             // no match!
             Logs.INVOCATION.tracef("Performed first-match discovery, no match");
         }
         return problems;
+    }
+
+    private static List<Throwable> merge(List<Throwable> problems, List<Throwable> problems2) {
+        if (problems2.isEmpty()) {
+            return problems;
+        } else if (problems.isEmpty()) {
+            return problems2;
+        } else {
+            final ArrayList<Throwable> problems3 = new ArrayList<>(problems.size() + problems2.size());
+            problems3.addAll(problems);
+            problems3.addAll(problems2);
+            return problems3;
+        }
     }
 
     private List<Throwable> doAnyDiscovery(AbstractInvocationContext context, final FilterSpec filterSpec, final EJBLocator<?> locator) {
@@ -361,6 +366,8 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         final Set<URI> blacklist = context.getAttachment(BL_KEY);
         final Map<URI, String> nodes = new HashMap<>();
         final Map<String, URI> uris = new HashMap<>();
+        final Map<URI, List<String>> clusterAssociations = new HashMap<>();
+
         int nodeless = 0;
         try (final ServicesQueue queue = discover(filterSpec)) {
             ServiceURL serviceURL;
@@ -382,7 +389,24 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                             nodeless++;
                         }
                     }
-                    context.setDestination(location);
+
+                    // Handle multiple cluster specifications per entry, and also multiple entries with
+                    // cluster specifications that refer to the same URI. Currently multi-membership is
+                    // represented in the latter form, however, handle the first form as well, just in
+                    // case this changes in the future.
+                    final List<AttributeValue> clusters = serviceURL.getAttributeValues(FILTER_ATTR_CLUSTER);
+                    if (clusters != null) {
+                        for (AttributeValue cluster : clusters) {
+                            List<String> list = clusterAssociations.putIfAbsent(location, Collections.singletonList(cluster.toString()));
+                            if (list != null) {
+                                if (!(list instanceof ArrayList)) {
+                                    list = new ArrayList<>(list);
+                                    clusterAssociations.put(location, list);
+                                }
+                                list.add(cluster.toString());
+                            }
+                        }
+                    }
                 }
             }
             problems = queue.getProblems();
@@ -430,9 +454,29 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             Logs.INVOCATION.tracef("Performed first-match discovery, nodes > 1, URI selector used(target affinity(node) = %s, destination = %s)", nodeName, location);
         }
 
+        // TODO DeploymentNodeSelector should be enhanced to handle URIs that are members of more than one cluster
+
+        // Clients typically do not have an auth policy for nodes which are dynamically discovered
+        // from cluster topology info. Anytime such a node is selected, we must register the
+        // associated cluster with the invocation, so that an effective auth config can be
+        // determined. Randomly pick a cluster if there is more than one.
+        selectCluster(context, clusterAssociations, location);
         context.setDestination(location);
         if (nodeName != null) context.setTargetAffinity(new NodeAffinity(nodeName));
         return problems;
+    }
+
+    private void selectCluster(AbstractInvocationContext context, Map<URI, List<String>> clusterAssociations, URI location) {
+        List<String> associations = clusterAssociations.get(location);
+        String cluster = null;
+        if (associations != null) {
+            cluster = (associations.size() == 1) ? associations.get(0) :
+                    associations.get(ThreadLocalRandom.current().nextInt(associations.size()));
+
+        }
+        if (cluster != null) {
+            context.setInitialCluster(cluster);
+        }
     }
 
     private List<Throwable> doClusterDiscovery(AbstractInvocationContext context, final FilterSpec filterSpec) {

--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -429,8 +429,7 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             Logs.INVOCATION.tracef("Performed first-match discovery(target affinity(node) = %s, destination = %s)", nodeName, location);
         } else if (nodeless == 0) {
             // use the deployment node selector
-            // todo: configure on client context
-            DeploymentNodeSelector selector = DeploymentNodeSelector.RANDOM;
+            DeploymentNodeSelector selector = context.getClientContext().getDeploymentNodeSelector();
             nodeName = selector.selectNode(nodes.values().toArray(NO_STRINGS), locator.getAppName(), locator.getModuleName(), locator.getDistinctName());
             if (nodeName == null) {
                 throw Logs.INVOCATION.selectorReturnedNull(selector);

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -575,6 +575,10 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         return clusterNodeSelector;
     }
 
+    DeploymentNodeSelector getDeploymentNodeSelector() {
+        return deploymentNodeSelector;
+    }
+
     static final class ClassInterceptor {
         private final String className;
         private final EJBClientInterceptorInformation interceptor;

--- a/src/main/java/org/jboss/ejb/protocol/remote/DiscoveredNodeRegistry.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/DiscoveredNodeRegistry.java
@@ -18,6 +18,7 @@
 
 package org.jboss.ejb.protocol.remote;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ interface DiscoveredNodeRegistry {
 
     List<NodeInformation> getAllNodeInformation();
 
-    void addNode(String clusterName, String nodeName);
+    void addNode(String clusterName, String nodeName, URI registeredBy);
 
     void removeNode(String clusterName, String nodeName);
 

--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
@@ -234,7 +234,7 @@ class EJBClientChannel {
                         int memberCount = StreamUtils.readPackedSignedInt32(message);
                         for (int j = 0; j < memberCount; j ++) {
                             final String nodeName = message.readUTF();
-                            discoveredNodeRegistry.addNode(clusterName, nodeName);
+                            discoveredNodeRegistry.addNode(clusterName, nodeName, channel.getConnection().getPeerURI());
                             final NodeInformation nodeInformation = discoveredNodeRegistry.getNodeInformation(nodeName);
                             Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY(%x) message, registering cluster %s to node %s", msg, clusterName, nodeName);
 

--- a/src/test/java/org/jboss/ejb/client/test/ClusterNodeSelectorTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClusterNodeSelectorTestCase.java
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.ejb.client.test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.ejb.client.ClusterAffinity;
+import org.jboss.ejb.client.ClusterNodeSelector;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientCluster;
+import org.jboss.ejb.client.EJBClientConnection;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.StatefulEJBLocator;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
+import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.Echo;
+import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.ejb.server.ClusterTopologyListener.ClusterInfo;
+import org.jboss.ejb.server.ClusterTopologyListener.NodeInfo;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests usage of ClusterNodeSelector
+ *
+ * @author Jason T. Greene
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class ClusterNodeSelectorTestCase {
+
+    private static final Logger logger = Logger.getLogger(ClusterNodeSelectorTestCase.class);
+    private static final String PROPERTIES_FILE = "cluster-node-selector-jboss-ejb-client.properties";
+
+    // servers
+    private static final String SERVER1_NAME = "node1";
+    private static final String SERVER2_NAME = "node2";
+
+    private DummyServer[] servers = new DummyServer[2];
+    private static String[] serverNames = {SERVER1_NAME, SERVER2_NAME};
+    private boolean[] serversStarted = new boolean[2] ;
+
+    // module
+    private static final String APP_NAME = "my-foo-app";
+    private static final String MODULE_NAME = "my-bar-module";
+    private static final String DISTINCT_NAME = "";
+
+    // cluster
+    // note: node names and server names should match!
+    private static final String CLUSTER_NAME = "ejb";
+    private static final String NODE1_NAME = "node1";
+    private static final String NODE2_NAME = "node2";
+
+    private static final NodeInfo NODE1 = DummyServer.getNodeInfo(NODE1_NAME, "localhost",6999,"0.0.0.0",0);
+    private static final NodeInfo NODE2 = DummyServer.getNodeInfo(NODE2_NAME, "localhost",7099,"0.0.0.0",0);
+    private static final ClusterInfo CLUSTER = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
+
+    public static class TestSelector implements ClusterNodeSelector  {
+        private static volatile String PICK_NODE = null;
+
+        @Override
+        public String selectNode(String clusterName, String[] connectedNodes, String[] totalAvailableNodes) {
+            if (PICK_NODE != null) {
+                return PICK_NODE;
+            }
+            return connectedNodes[0];
+        }
+    }
+
+
+    /**
+     * Do any general setup here
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // trigger the static init of the correct properties file - this also depends on running in forkMode=always
+        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
+        JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
+
+        // Launch callback if needed
+        ClassCallback.beforeClassCallback();
+    }
+
+    /**
+     * Do any test specific setup here
+     */
+    @Before
+    public void beforeTest() throws Exception {
+
+        // start a server
+        servers[0] = new DummyServer("localhost", 6999, serverNames[0]);
+        servers[0].start();
+        serversStarted[0] = true;
+        logger.info("Started server " + serverNames[0]);
+
+        // start a server
+        servers[1] = new DummyServer("localhost", 7099, serverNames[1]);
+        servers[1].start();
+        serversStarted[1] = true;
+        logger.info("Started server " + serverNames[1]);
+
+        // deploy modules
+        servers[0].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean(NODE1_NAME));
+        logger.info("Registered module on server " + servers[0]);
+
+        servers[1].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean(NODE2_NAME));
+        logger.info("Registered module on server " + servers[1]);
+
+        // define clusters
+        servers[0].addCluster(CLUSTER);
+        logger.info("Added node to cluster " + CLUSTER_NAME + ": server " + servers[1]);
+        servers[1].addCluster(CLUSTER);
+        logger.info("Added node to cluster " +  CLUSTER_NAME +":  server " + servers[1]);
+    }
+
+    @Test
+    public void testConfiguredConnections() {
+        EJBClientContext context = EJBClientContext.getCurrent();
+        List<EJBClientConnection> connections = context.getConfiguredConnections();
+
+        Assert.assertEquals("Number of configured connections for this context is incorrect", 2, connections.size());
+        for (EJBClientConnection connection : connections) {
+            logger.info("found connection: destination = " + connection.getDestination() + ", forDiscovery = " + connection.isForDiscovery());
+        }
+
+        Collection<EJBClientCluster> clusters = context.getInitialConfiguredClusters();
+        for (EJBClientCluster cluster: clusters) {
+            logger.info("found cluster: name = " + cluster.getName());
+        }
+    }
+
+    /**
+     * Test a basic invocation on clustered SLSB
+     */
+    @Test
+    public void testClusteredSLSBInvocation() {
+        logger.info("Testing invocation on SLSB proxy with ClusterAffinity");
+
+        // create a proxy for invocation
+        final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
+        final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+
+        EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        logger.info("Invoking on proxy...");
+
+        TestSelector.PICK_NODE = NODE1_NAME;
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(NODE1_NAME, proxy.whoAreYou());
+        }
+
+        TestSelector.PICK_NODE = NODE2_NAME;
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(NODE2_NAME, proxy.whoAreYou());
+        }
+    }
+
+    /**
+     * Test a basic invocation on clustered SFSB
+     */
+    @Test
+    public void testClusteredSFSBInvocation() throws Exception {
+        logger.info("Testing invocation on SFSB proxy with ClusterAffinity");
+
+        TestSelector.PICK_NODE = NODE2_NAME;
+        // create a proxy for invocation
+        final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
+        StatefulEJBLocator<Echo> statefulEJBLocator = null;
+        statefulEJBLocator = EJBClient.createSession(statelessEJBLocator.withNewAffinity(new ClusterAffinity("ejb")));
+
+        Echo proxy = EJBClient.createProxy(statefulEJBLocator);
+        Assert.assertNotNull("Received a null proxy", proxy);
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(NODE2_NAME, proxy.whoAreYou());
+        }
+
+        TestSelector.PICK_NODE = NODE1_NAME;
+        statefulEJBLocator = EJBClient.createSession(statelessEJBLocator.withNewAffinity(new ClusterAffinity("ejb")));
+        proxy = EJBClient.createProxy(statefulEJBLocator);
+
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(NODE1_NAME, proxy.whoAreYou());
+        }
+    }
+
+    /**
+     * Do any test-specific tear down here.
+     */
+    @After
+    public void afterTest() {
+        servers[0].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+        logger.info("Unregistered module from " + serverNames[0]);
+
+        servers[1].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+        logger.info("Unregistered module from " + serverNames[1]);
+
+        servers[0].removeCluster(CLUSTER_NAME);
+        servers[1].removeCluster(CLUSTER_NAME);
+
+        if (serversStarted[0]) {
+            try {
+                this.servers[0].stop();
+            } catch (Throwable t) {
+                logger.info("Could not stop server", t);
+            }
+        }
+        logger.info("Stopped server " + serverNames[0]);
+
+        if (serversStarted[1]) {
+            try {
+                this.servers[1].stop();
+            } catch (Throwable t) {
+                logger.info("Could not stop server", t);
+            }
+        }
+        logger.info("Stopped server " + serverNames[1]);
+    }
+
+    /**
+     * Do any general tear down here.
+     */
+    @AfterClass
+    public static void afterClass() {
+    }
+
+}

--- a/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
@@ -158,7 +158,10 @@ public class ClusteredInvocationTestCase {
         logger.info("Invoking on proxy...");
         // invoke on the proxy (use a ClusterAffinity for now)
         final String message = "hello!";
-        final String echo = proxy.echo(message);
+         String echo = null;
+        for (int i = 0; i < 10; i++) {
+           echo = proxy.echo(message);
+        }
         Assert.assertEquals("Got an unexpected echo", echo, message);
     }
 

--- a/src/test/java/org/jboss/ejb/client/test/DeploymentNodeSelectorTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/DeploymentNodeSelectorTestCase.java
@@ -1,0 +1,200 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.ejb.client.test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
+import com.arjuna.ats.internal.jbossatx.jta.jca.XATerminator;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import org.jboss.ejb.client.ClusterAffinity;
+import org.jboss.ejb.client.DeploymentNodeSelector;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.StatefulEJBLocator;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
+import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.Echo;
+import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.naming.client.WildFlyInitialContextFactory;
+import org.wildfly.naming.client.WildFlyRootContext;
+import org.wildfly.naming.client.util.FastHashtable;
+import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
+import org.wildfly.transaction.client.LocalTransactionContext;
+import org.wildfly.transaction.client.LocalUserTransaction;
+import org.wildfly.transaction.client.RemoteTransactionContext;
+import org.wildfly.transaction.client.provider.jboss.JBossLocalTransactionProvider;
+
+/**
+ * Tests DeploymentNodeSelector
+ *
+ * @author Jason T. Greene
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class DeploymentNodeSelectorTestCase {
+    private static final Logger logger = Logger.getLogger(DeploymentNodeSelectorTestCase.class);
+    private static ContextTransactionManager txManager;
+    private static ContextTransactionSynchronizationRegistry txSyncRegistry;
+
+    private DummyServer server1, server2, server3, server4;
+    private boolean serverStarted = false;
+
+    // module
+    private static final String APP_NAME = "my-foo-app";
+    private static final String MODULE_NAME = "my-bar-module";
+    private static final String DISTINCT_NAME = "";
+
+    private static final String SERVER1_NAME = "server1";
+    private static final String SERVER2_NAME = "server2";
+
+    /**
+     * Do any general setup here
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        String PROPERTIES_FILE = "deployment-node-selector-jboss-ejb-client.properties";
+
+        // trigger the static init of the correct properties file - this also depends on running in forkMode=always
+        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
+        JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
+
+        // Launch callback if needed
+        ClassCallback.beforeClassCallback();
+    }
+
+    /**
+     * Do any test specific setup here
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        // start a server
+        server1 = new DummyServer("localhost", 6999, SERVER1_NAME, true);
+        server2 = new DummyServer("localhost", 7999, SERVER2_NAME, true);
+        server1.start();
+        server2.start();
+        serverStarted = true;
+        logger.info("Started servers ...");
+
+        server1.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER1_NAME));
+        server2.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER2_NAME));
+    }
+
+    public static class TestSelector implements DeploymentNodeSelector {
+        private static volatile String PICK_NODE = null;
+
+        @Override
+        public String selectNode(String[] eligibleNodes, String appName, String moduleName, String distinctName) {
+            if (PICK_NODE != null) {
+                return PICK_NODE;
+            }
+            return eligibleNodes[0];
+        }
+    }
+
+    @Test
+      public void testSLSBInvocation() {
+          // create a proxy for invocation
+          final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, EchoBean.class.getSimpleName(), DISTINCT_NAME);
+          final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+
+          Assert.assertNotNull("Received a null proxy", proxy);
+          logger.info("Created proxy for Echo: " + proxy.toString());
+
+          logger.info("Invoking on proxy...");
+
+          TestSelector.PICK_NODE = SERVER1_NAME;
+          for (int i = 0; i < 10; i++) {
+              Assert.assertEquals(SERVER1_NAME, proxy.whoAreYou());
+          }
+
+          TestSelector.PICK_NODE = SERVER2_NAME;
+          for (int i = 0; i < 10; i++) {
+              Assert.assertEquals(SERVER2_NAME, proxy.whoAreYou());
+          }
+      }
+
+      /**
+       * Test a basic invocation on clustered SFSB
+       */
+      @Test
+      public void testSFSBInvocation() throws Exception {
+          TestSelector.PICK_NODE = SERVER2_NAME;
+          // create a proxy for invocation
+          final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, EchoBean.class.getSimpleName(), DISTINCT_NAME);
+          StatefulEJBLocator<Echo> statefulEJBLocator = null;
+          statefulEJBLocator = EJBClient.createSession(statelessEJBLocator);
+
+          Echo proxy = EJBClient.createProxy(statefulEJBLocator);
+          Assert.assertNotNull("Received a null proxy", proxy);
+          for (int i = 0; i < 10; i++) {
+              Assert.assertEquals(SERVER2_NAME, proxy.whoAreYou());
+          }
+
+          TestSelector.PICK_NODE = SERVER1_NAME;
+          statefulEJBLocator = EJBClient.createSession(statelessEJBLocator);
+          proxy = EJBClient.createProxy(statefulEJBLocator);
+          for (int i = 0; i < 10; i++) {
+              Assert.assertEquals(SERVER1_NAME, proxy.whoAreYou());
+          }
+      }
+    /**
+     * Do any test-specific tear down here.
+     */
+    @After
+    public void afterTest() {
+        server1.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+        server2.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+        logger.info("Unregistered module ...");
+
+        if (serverStarted) {
+            try {
+                this.server1.stop();
+                this.server2.stop();
+            } catch (Throwable t) {
+                logger.info("Could not stop server", t);
+            }
+        }
+        logger.info("Stopped server ...");
+    }
+
+    /**
+     * Do any general tear down here.
+     */
+    @AfterClass
+    public static void afterClass() {
+    }
+
+}

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -56,8 +56,9 @@ import org.wildfly.transaction.client.RemoteTransactionContext;
 import org.wildfly.transaction.client.provider.jboss.JBossLocalTransactionProvider;
 
 /**
- * Tests basic invocation of a bean deployed on a single server node.
+ * Tests transaction stickiness
  *
+ * @author Jason T. Greene
  * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
 public class TransactionTestCase {

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -17,8 +17,10 @@
  */
 package org.jboss.ejb.client.test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +43,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.naming.client.WildFlyRootContext;
 import org.wildfly.naming.client.util.FastHashtable;
@@ -57,7 +61,6 @@ import org.wildfly.transaction.client.provider.jboss.JBossLocalTransactionProvid
  * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
 public class TransactionTestCase {
-
     private static final Logger logger = Logger.getLogger(TransactionTestCase.class);
     private static ContextTransactionManager txManager;
     private static ContextTransactionSynchronizationRegistry txSyncRegistry;
@@ -212,7 +215,7 @@ public class TransactionTestCase {
             txManager.begin();
             HashMap<String, Integer> replies = new HashMap<>();
             String id = null;
-            for (int i = 0; i < 20; i++) {
+            for (int i = 0; i < 30; i++) {
 
                 Echo echo = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + EchoBean.class.getSimpleName() + "!"
                         + Echo.class.getName() + (stateful ? "?stateful" : ""));
@@ -223,7 +226,9 @@ public class TransactionTestCase {
 
             // Everything should clump to one node under this transaction
             Assert.assertEquals(sticky ? 1 : 3, replies.size());
-            //Assert.assertEquals(20, replies.values().iterator().next().intValue());
+            if (sticky) {
+                Assert.assertEquals(30, replies.values().iterator().next().intValue());
+            }
             ids.add(id);
             txManager.commit();
         }
@@ -247,7 +252,7 @@ public class TransactionTestCase {
 
         HashSet<String> id1s = new HashSet<>();
         HashSet<String> id2s = new HashSet<>();
-        for (int attempts = 0; attempts < 40; attempts++) {
+        for (int attempts = 0; attempts < 80; attempts++) {
             txManager.begin();
             HashMap<String, Integer> replies = new HashMap<>();
             String id1 = null;
@@ -290,7 +295,7 @@ public class TransactionTestCase {
             txManager.commit();
         }
 
-        // After 20 tries, we should have hit every server for each app
+        // After 80 tries, we should have hit every server for each app
         Assert.assertEquals(Stream.of("server1", "server3", "server4").collect(Collectors.toSet()), id1s);
         Assert.assertEquals(Stream.of("server2", "server3", "server4").collect(Collectors.toSet()), id2s);
     }

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
@@ -99,7 +99,7 @@ public class DummyServer {
         final OptionMap options = OptionMap.EMPTY;
         EndpointBuilder endpointBuilder = Endpoint.builder();
         endpointBuilder.setEndpointName(this.endpointName);
-        endpointBuilder.buildXnioWorker(Xnio.getInstance()).populateFromOptions(options).build();
+        endpointBuilder.buildXnioWorker(Xnio.getInstance()).populateFromOptions(options);
         endpoint = endpointBuilder.build();
 
 

--- a/src/test/resources/cluster-node-selector-jboss-ejb-client.properties
+++ b/src/test/resources/cluster-node-selector-jboss-ejb-client.properties
@@ -1,0 +1,47 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=one,two
+
+# connection to a node at protocol://host:port
+remote.connection.one.host=localhost
+remote.connection.one.port=6999
+remote.connection.one.protocol=remote
+remote.connection.one.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.one.username=test
+remote.connection.one.password=test
+remote.connection.one.realm=default
+
+# connection to a node at protocol://host:port
+remote.connection.two.host=localhost
+remote.connection.two.port=7099
+remote.connection.two.protocol=remote
+remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.two.username=test
+remote.connection.two.password=test
+remote.connection.two.realm=default
+
+# the nodes are clustered in a cluster called ejb and have names node1, node2
+remote.clusters=ejb
+remote.cluster.ejb.node.node1.username=test
+remote.cluster.ejb.node.node1.password=test
+remote.cluster.ejb.clusternode.selector=org.jboss.ejb.client.test.ClusterNodeSelectorTestCase$TestSelector
+#remote.cluster.ejb.node.node2.username=test
+#remote.cluster.ejb.node.node2.password=test

--- a/src/test/resources/clustered-jboss-ejb-client.properties
+++ b/src/test/resources/clustered-jboss-ejb-client.properties
@@ -42,5 +42,5 @@ remote.connection.two.realm=default
 remote.clusters=ejb
 remote.cluster.ejb.node.node1.username=test
 remote.cluster.ejb.node.node1.password=test
-remote.cluster.ejb.node.node2.username=test
-remote.cluster.ejb.node.node2.password=test
+#remote.cluster.ejb.node.node2.username=test
+#remote.cluster.ejb.node.node2.password=test

--- a/src/test/resources/deployment-node-selector-jboss-ejb-client.properties
+++ b/src/test/resources/deployment-node-selector-jboss-ejb-client.properties
@@ -1,0 +1,42 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=one,two
+
+deployment.node.selector=org.jboss.ejb.client.test.DeploymentNodeSelectorTestCase$TestSelector
+
+# connection to a node at protocol://host:port
+remote.connection.one.host=localhost
+remote.connection.one.port=6999
+remote.connection.one.protocol=remote
+remote.connection.one.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.one.username=test
+remote.connection.one.password=test
+remote.connection.one.realm=default
+
+# connection to a node at protocol://host:port
+remote.connection.two.host=localhost
+remote.connection.two.port=7999
+remote.connection.two.protocol=remote
+remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.two.username=test
+remote.connection.two.password=test
+remote.connection.two.realm=default
+


### PR DESCRIPTION
[EJBCLIENT-284](https://issues.jboss.org/browse/EJBCLIENT-284) Configured (Deployment|Cluster)NodeSelector isn't used   
[EJBCLIENT-285](https://issues.jboss.org/browse/EJBCLIENT-285) Reuse seed connection auth config for cluster topology created connections
