### PR TITLE
[EJBCLIENT-295] EJB Client Interceptor being called more than once

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBProxyInformation.java
+++ b/src/main/java/org/jboss/ejb/client/EJBProxyInformation.java
@@ -108,7 +108,7 @@ final class EJBProxyInformation<T> {
                         final boolean clientAsync = alwaysAsync || classAsync || ENABLE_SCANNING && method.getAnnotation(ClientAsynchronous.class) != null;
                         final CompressionHint compressionHint = ENABLE_SCANNING ? method.getAnnotation(CompressionHint.class) : null;
                         final ClientTransaction transactionHint = ENABLE_SCANNING ? method.getAnnotation(ClientTransaction.class) : null;
-                        final ClientInterceptors clientInterceptors = ENABLE_SCANNING ? type.getAnnotation(ClientInterceptors.class) : null;
+                        final ClientInterceptors clientInterceptors = ENABLE_SCANNING ? method.getAnnotation(ClientInterceptors.class) : null;
                         final EJBClientContext.InterceptorList interceptors = getInterceptorsFromAnnotation(clientInterceptors);
                         final int compressionLevel;
                         final boolean compressRequest;


### PR DESCRIPTION
Client interceptor annotation at method level is retrieving the annotation at the class level. It will end up with duplicated interceptors.

Jira issue: https://issues.jboss.org/browse/EJBCLIENT-295
JBEAP Issue: https://issues.jboss.org/browse/JBEAP-14246