### PR TITLE
[WFTC-54] don't permit to outflow transaction with already elapsed timeout

### DIFF
--- a/src/main/java/org/jboss/ejb/_private/Logs.java
+++ b/src/main/java/org/jboss/ejb/_private/Logs.java
@@ -46,6 +46,7 @@ import javax.naming.Name;
 import javax.naming.NamingException;
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
+import javax.transaction.Transaction;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
@@ -331,6 +332,9 @@ public interface Logs extends BasicLogger {
 
     @Message(id = 81, value = "Failed to instantiate cluster node selector class \"%s\"")
     IllegalArgumentException cannotInstantiateClustertNodeSelector(String name, @Cause ReflectiveOperationException e);
+
+    @Message(id = 82, value = "Cannot outflow the remote transaction \"%s\" as its timeout elapsed")
+    SystemException outflowTransactionTimeoutElapsed(Transaction transaction);
 
     // Proxy API errors
 

--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
@@ -560,7 +560,9 @@ class EJBClientChannel {
             if (ir == null) throw Logs.TXN.cannotEnlistTx();
             final int id = ir.getTransactionId(channel.getConnection());
             dataOutput.writeInt(id);
-            PackedInteger.writePackedInteger(dataOutput, remoteTransaction.getEstimatedRemainingTime());
+            int transactionTimeout = remoteTransaction.getEstimatedRemainingTime();
+            if(transactionTimeout == 0) throw Logs.TXN.outflowTransactionTimeoutElapsed(transaction);
+            PackedInteger.writePackedInteger(dataOutput, transactionTimeout);
             return null;
         } else if (transaction instanceof LocalTransaction) {
             final LocalTransaction localTransaction = (LocalTransaction) transaction;
@@ -575,7 +577,9 @@ class EJBClientChannel {
             // this will normally be zero, but write it anyway just in case we need to change it later
             dataOutput.writeByte(bq.length);
             dataOutput.write(bq);
-            PackedInteger.writePackedInteger(dataOutput, outflowHandle.getRemainingTime());
+            int transactionTimeout = outflowHandle.getRemainingTime();
+            if(transactionTimeout == 0) throw Logs.TXN.outflowTransactionTimeoutElapsed(transaction);
+            PackedInteger.writePackedInteger(dataOutput, transactionTimeout);
             return outflowHandle;
         } else {
             throw Logs.TXN.cannotEnlistTx();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFTC-54

if a transaction is for outflow but the timeout already elapsed then throw exception rather than passing it through the channel to the receiver (see https://issues.jboss.org/browse/WFTC-54?focusedCommentId=13677791#comment-13677791)