### PR TITLE
[EJBCLIENT-319] Update affinities on return in NamingEJBClientInterceptor

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClient.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClient.java
@@ -199,6 +199,10 @@ public final class EJBClient {
         final T proxy = createProxy(statefulLocator, authenticationContextSupplier);
         final Affinity weakAffinity = context.getWeakAffinity();
 
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("createSessionProxy: strong affinity = %s, weak affinity = %s", statefulLocator.getAffinity(), context.getWeakAffinity());
+        }
+
         if (weakAffinity != null && Affinity.NONE != weakAffinity) {
             setWeakAffinity(proxy, weakAffinity);
         }

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -825,7 +825,9 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         // Special hook for naming; let's replace this sometime soon.
         if (namingProvider != null) context.putAttachment(Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
 
-        Logs.INVOCATION.tracef("Calling createSession(locator = %s)",statelessLocator);
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("Calling createSession(locator = %s)", statelessLocator);
+        }
 
         SessionID sessionID = null;
         for (int i = 0; i < MAX_SESSION_RETRIES; i++) {
@@ -855,9 +857,15 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
             if (i == MAX_SESSION_RETRIES - 1) {
                 throw new RequestSendFailedException(t.getMessage() + " (maximum retries exceeded)", t);
             }
-            Logs.INVOCATION.tracef("Retrying invocation (attempt %d): %s", i + 1, statelessLocator);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("Retrying invocation (attempt %d): %s", i + 1, statelessLocator);
+            }
         }
         final Affinity affinity = context.getLocator().getAffinity();
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("Session created: session id: %s , affinity: %s", sessionID, affinity);
+        }
 
         return statelessLocator.withSessionAndAffinity(sessionID, affinity);
     }

--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -460,6 +460,10 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 final URI destination = getDestination();
                 final EJBReceiver receiver;
                 try {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("sendRequest: setting receiver, strong affinity = %s, weak affinity = %s, remote destination is: %s",
+                                getLocator().getAffinity(), invocationHandler.getWeakAffinity(), destination);
+                    }
                     receiver = getClientContext().resolveReceiver(destination, getLocator());
                 } catch (Throwable t) {
                     synchronized (lock) {
@@ -488,6 +492,9 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 }
             } else {
                 try {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("sendRequest: calling interceptor: %s", chain[idx].getInterceptorInstance());
+                    }
                     chain[idx].getInterceptorInstance().handleInvocation(this);
                 } catch (Throwable t) {
                     synchronized (lock) {
@@ -643,6 +650,9 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 throw t;
             } finally {
                 if (idx == 0) {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("getResult(): invocation returned, relocating EJB: strong affinity = %s, weak affinity = %s", getLocator().getAffinity(), getWeakAffinity());
+                    }
                     // relocate the EJB
                     invocationHandler.setWeakAffinity(getWeakAffinity());
                     invocationHandler.setStrongAffinity(getLocator().getAffinity());

--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -86,6 +86,10 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
         if (locator instanceof StatefulEJBLocator) {
             // set the weak affinity to the node on which the session was created
             setWeakAffinity(locator.getAffinity());
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("EJBInvocationHandler: setting weak affinity = %s", locator.getAffinity());
+            }
         }
     }
 
@@ -103,6 +107,10 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
         if (locator instanceof StatefulEJBLocator) {
             // set the weak affinity to the node on which the session was created
             setWeakAffinity(locator.getAffinity());
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("EJBInvocationHandler(constructor): setting weak affinity = %s", locator.getAffinity());
+            }
         }
     }
 

--- a/src/main/java/org/jboss/ejb/client/EJBRootContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBRootContext.java
@@ -154,11 +154,17 @@ class EJBRootContext extends AbstractContext {
         final Object proxy;
         if (stateful) {
             try {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("lookupNative: createSessionProxy, locator = %s, baseAffinity = %s", statelessLocator, baseAffinity.get());
+                }
                 proxy = EJBClient.createSessionProxy(statelessLocator, providerEnvironment.getAuthenticationContextSupplier(), namingProvider);
             } catch (Exception e) {
                 throw Logs.MAIN.lookupFailed(name, name, e);
             }
         } else {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("lookupNative: createProxy, locator = %s", statelessLocator);
+            }
             proxy = EJBClient.createProxy(statelessLocator, providerEnvironment.getAuthenticationContextSupplier());
         }
         if (namingProvider != null) EJBClient.putProxyAttachment(proxy, Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
@@ -171,6 +177,10 @@ class EJBRootContext extends AbstractContext {
         Long invocationTimeout = getLongValueFromEnvironment(PROPERTY_KEY_INVOCATION_TIMEOUT);
         if (invocationTimeout != null) {
             EJBClient.setInvocationTimeout(proxy, invocationTimeout.longValue(), TimeUnit.MILLISECONDS);
+        }
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("lookupNative: created proxy, locator = %s, weakAffinity = %s", EJBClient.getLocatorFor(proxy), EJBClient.getWeakAffinity(proxy));
         }
 
         return proxy;

--- a/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
@@ -59,6 +59,9 @@ public final class EJBSessionCreationInvocationContext extends AbstractInvocatio
             if (chain.length == idx) {
                 final URI destination = getDestination();
                 final EJBReceiver receiver = getClientContext().resolveReceiver(destination, getLocator());
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("session creation proceed(): setting receiver, remote destination is: %s", destination);
+                }
                 setReceiver(receiver);
                 final SessionID sessionID = receiver.createSession(new EJBReceiverSessionCreationContext(this, authenticationContext));
                 if (sessionID == null) {
@@ -67,6 +70,9 @@ public final class EJBSessionCreationInvocationContext extends AbstractInvocatio
                 retry = false;
                 return sessionID;
             } else {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("session creation proceed(): calling interceptor: %s", chain[idx].getInterceptorInstance());
+                }
                 return chain[idx].getInterceptorInstance().handleSessionCreation(this);
             }
         } finally {

--- a/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
@@ -60,9 +60,15 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             context.putAttachment(Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
         }
         if (namingProvider == null || context.getDestination() != null || context.getLocator().getAffinity() != Affinity.NONE) {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling handleInvocation: skipping missing target");
+            }
             context.putAttachment(SKIP_MISSING_TARGET, Boolean.TRUE);
             context.sendRequest();
         } else {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling handleInvocation: setting destination");
+            }
             if (setDestination(context, namingProvider)) try {
                 context.sendRequest();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -93,7 +99,23 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             return context.proceed();
         } else {
             if (setDestination(context, namingProvider)) try {
-                return context.proceed();
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("NamingEJBClientInterceptor: called setNamingDestination: destination = %s", context.getDestination());
+                }
+                SessionID theSessionID = context.proceed();
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("NamingEJBClientInterceptor: returned from handleSessionCreation: sessionID = %s", theSessionID);
+                }
+                // we should setup session affinities here
+                if (context instanceof EJBSessionCreationInvocationContext) {
+                    // this will convert strong=NONE to target or URI (if target not defined)
+                    // this will also convert strong=Cluster and weak = NONE to strong=Cluster and weak = target or URI (if target not defined)
+                    DiscoveryEJBClientInterceptor.setupSessionAffinities((EJBSessionCreationInvocationContext)context);
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("NamingEJBClientInterceptor: called DiscoveryEJBClientInterceptor.setupSessionAffinities");
+                    }
+                }
+                return theSessionID;
             } catch (NoSuchEJBException | RequestSendFailedException e) {
                 processMissingTarget(context);
                 throw e;
@@ -122,8 +144,12 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
     static boolean setNamingDestination(final AbstractInvocationContext context, final NamingProvider namingProvider) {
         final ProviderEnvironment providerEnvironment = namingProvider.getProviderEnvironment();
         final List<URI> providerUris = providerEnvironment.getProviderUris();
-
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling setNamingDestination: providerURIs = %s, invocationContext type = %s", providerUris.toString(), context.getClass().getName());
+        }
+        // select the subset of providerURIs that agree with TransactionInterceptor's choices
         List<URI> uris = findPreferredURIs(context, providerUris);
+        // if there are none, use all non-blacklisted providerURIs instead
         if (uris == null) {
             uris = new ArrayList<>(providerUris.size());
             for (URI uri : providerUris) {
@@ -139,15 +165,16 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             return false;
         } else if (size == 1) {
             context.setDestination(uris.get(0));
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: setting destination: (size == 1), destination = %s", context.getDestination());
+            }
             return true;
         } else {
             context.setDestination(uris.get(ThreadLocalRandom.current().nextInt(size)));
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: setting destination: (size > 1), destination = %s", context.getDestination());
+            }
         }
-
-        if (context instanceof EJBSessionCreationInvocationContext) {
-            DiscoveryEJBClientInterceptor.setupSessionAffinities((EJBSessionCreationInvocationContext)context);
-        }
-
         return true;
     }
 
@@ -167,6 +194,9 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
                 result.add(check);
             }
         }
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: computing preffered URIs: URIs = %s, preferred URIs = %s", uris, result);
+        }
 
         return result;
     }
@@ -178,6 +208,10 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             return;
         }
 
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: missing target, *** retrying ***: locator = %s", context.getLocator());
+        }
+
         // Oops, we got some wrong information!
         addBlackListedDestination(context, destination);
 
@@ -185,6 +219,11 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
         if (! (locator.getAffinity() instanceof ClusterAffinity)) {
             // it *was* "none" affinity, but it has been relocated; locate it back again
             context.setLocator(locator.withNewAffinity(Affinity.NONE));
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: resetting strong affinity = %s", context.getLocator().getAffinity());
+            }
+
         }
         // clear the weak affinity so that cluster invocations can be re-targeted.
         context.setWeakAffinity(Affinity.NONE);

--- a/src/main/java/org/jboss/ejb/client/TransactionPostDiscoveryInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/TransactionPostDiscoveryInterceptor.java
@@ -63,6 +63,9 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (applications != null) {
             URI destination = context.getDestination();
             Application registered = updateOrFollowApplication(context, applications, true);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling handleInvocation, destination = %s, application = %s", destination, registered);
+            }
             try {
                 context.sendRequest();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -85,6 +88,9 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (applications != null) {
             URI destination = context.getDestination();
             Application registered = updateOrFollowApplication(context, applications, false);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling handleSessionCreation, destination = %s, application = %s", destination, registered);
+            }
             try {
                 return context.proceed();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -107,12 +113,21 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (destination != null) {
             EJBIdentifier identifier = context.getLocator().getIdentifier();
             Application application = toApplication(identifier);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, destination = %s, application = %s", destination, application);
+            }
             URI existing = applications.putIfAbsent(application, destination);
             if (existing != null) {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, updating from map, destination = %s", existing);
+                }
                 // Someone else set a mapping, use it instead
                 context.setDestination(existing);
             } else {
                 if (register) {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, added destination for application, application = %s", application);
+                    }
                     context.putAttachment(APPLICATION, application);
                 }
 

--- a/src/main/java/org/jboss/ejb/client/URIAffinity.java
+++ b/src/main/java/org/jboss/ejb/client/URIAffinity.java
@@ -36,7 +36,7 @@ public final class URIAffinity extends Affinity {
      *
      * @param uri the URI to bind to (must not be {@code null})
      */
-    URIAffinity(final URI uri) {
+    public URIAffinity(final URI uri) {
         if (uri == null) {
             throw new IllegalArgumentException("URI is null");
         }

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -180,6 +180,7 @@ public class TransactionTestCase {
         HashSet<String> ids = new HashSet<>();
 
         for (int attempts = 0; attempts < 40; attempts++) {
+            System.out.println("\n *** Starting transaction # " + attempts + " ***\n");
             transaction.begin();
             HashMap<String, Integer> replies = new HashMap<>();
             String id = null;
@@ -196,6 +197,7 @@ public class TransactionTestCase {
             Assert.assertEquals(1, replies.size());
             Assert.assertEquals(20, replies.values().iterator().next().intValue());
             ids.add(id);
+            System.out.println("\n*** Committing transaction # " + attempts + " ***\n");
             transaction.commit();
         }
 


### PR DESCRIPTION
This PR addresses a problem in affinity processing with the EJB client when the NamingEJBClientInterceptor is used to discover a destination for an invocation. 

See the issue for more details: https://issues.jboss.org/browse/EJBCLIENT-319
It is required for the changes in https://issues.jboss.org/browse/WFLY-11489

