### PR TITLE
[EJBCLIENT-319] (4.x) Update affinities on return in NamingEJBClientInterceptor

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -88,9 +88,15 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
 
     public void handleInvocation(final EJBClientInvocationContext context) throws Exception {
         if (context.getDestination() != null) {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling handleInvocation - destination already discovered (destination = %s)", context.getDestination());
+            }
             // already discovered!
             context.sendRequest();
             return;
+        }
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling handleInvocation - calling executeDiscovery");
         }
         List<Throwable> problems = executeDiscovery(context);
         if(WILDFLY_TESTSUITE_HACK && context.getDestination() == null) {
@@ -122,10 +128,17 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             // set the weak affinity to the location of the session (in case it failed over)
             final Affinity targetAffinity = context.getTargetAffinity();
             if (targetAffinity != null) {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling handleInvocationResult - stateful, clustered case, setting weakAffinity to targetAffinty = %s", targetAffinity);
+                }
+
                 context.setWeakAffinity(targetAffinity);
             } else {
                 final URI destination = context.getDestination();
                 if (destination != null) {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling handleInvocationResult - stateful, clustered case, setting weakAffinity to URIAffintiy = %s", URIAffinity.forUri(destination));
+                    }
                     context.setWeakAffinity(URIAffinity.forUri(destination));
                 }
                 // if destination is null, then an interceptor set the location
@@ -135,8 +148,14 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
     }
 
     public SessionID handleSessionCreation(final EJBSessionCreationInvocationContext context) throws Exception {
+
+        Logs.INVOCATION.tracef("DiscoveryEJBClientInterceptor: calling handleSessionCreation (locator = %s, weak affinity = %s)", context.getLocator(), context.getWeakAffinity());
+
         if (context.getDestination() != null) {
             // already discovered!
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling handleSessionCreation - destination already discovered (destination = %s)", context.getDestination());
+            }
             return context.proceed();
         }
         List<Throwable> problems = executeDiscovery(context);
@@ -155,6 +174,10 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             throw withSuppressed(t, problems);
         }
         setupSessionAffinities(context);
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: session affinities have been setup (locator = %s, weak affinity = %s)", context.getLocator(), context.getWeakAffinity());
+        }
         return sessionID;
     }
 
@@ -169,6 +192,13 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
      */
     static void setupSessionAffinities(EJBSessionCreationInvocationContext context) {
         final EJBLocator<?> locator = context.getLocator();
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: setting up session affinities for new session bean: (locator = %s, weak affinity = %s, targetAffinity = %s)", context.getLocator(), context.getWeakAffinity(), context.getTargetAffinity());
+        }
+
+        // since this only affects session creations, this could be used to handle non-clustered beans (strong=Node, weak=None)
+
         if (locator.getAffinity() == Affinity.NONE) {
             // physically relocate this EJB
             final Affinity targetAffinity = context.getTargetAffinity();
@@ -195,6 +225,11 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                 // if destination is null, then an interceptor set the location
             }
         }
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: set up session affinities for new session bean: (locator = %s, weak affinity = %s, targetAffinity = %s)", context.getLocator(), context.getWeakAffinity(), context.getTargetAffinity());
+        }
+
     }
 
     private void processMissingTarget(final AbstractInvocationContext context) {
@@ -225,7 +260,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                     set = appearing;
                 }
             }
-            Logs.INVOCATION.tracef("Blacklisting destination (locator = %s, weak affinity = %s, missing target = %s)", context.getLocator(), context.getWeakAffinity(), destination);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: blacklisting destination (locator = %s, weak affinity = %s, missing target = %s)", context.getLocator(), context.getWeakAffinity(), destination);
+            }
 
             return set.add(destination);
         } else {
@@ -252,7 +289,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         final Affinity affinity = locator.getAffinity();
         final Affinity weakAffinity = context.getWeakAffinity();
 
-        Logs.INVOCATION.tracef("Calling executeDiscovery(locator = %s, weak affinity = %s)", locator, weakAffinity);
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: calling executeDiscovery(locator = %s, weak affinity = %s)", locator, weakAffinity);
+        }
 
         FilterSpec filterSpec, fallbackFilterSpec;
 
@@ -307,7 +346,10 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
     }
 
     private List<Throwable> doFirstMatchDiscovery(AbstractInvocationContext context, final FilterSpec filterSpec, final FilterSpec fallbackFilterSpec) {
-        Logs.INVOCATION.tracef("Performing first-match discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performing first-match discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
+        }
         final List<Throwable> problems;
         final Set<URI> set = context.getAttachment(BL_KEY);
         try (final ServicesQueue queue = discover(filterSpec)) {
@@ -324,7 +366,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                         context.setTargetAffinity(URIAffinity.forUri(location));
                     }
                     context.setDestination(location);
-                    Logs.INVOCATION.tracef("Performed first-match discovery(target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed first-match discovery(target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+                    }
                     return queue.getProblems();
                 }
             }
@@ -336,11 +380,15 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         // No good; fall back to cluster discovery.
         if (fallbackFilterSpec != null) {
             assert context.getLocator().getAffinity() instanceof ClusterAffinity;
-            Logs.INVOCATION.tracef("Performed first-match discovery, no match, falling back to cluster discovery");
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed first-match discovery, no match, falling back to cluster discovery");
+            }
             return merge(problems, doClusterDiscovery(context, fallbackFilterSpec));
         } else {
             // no match!
-            Logs.INVOCATION.tracef("Performed first-match discovery, no match");
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed first-match discovery, no match");
+            }
         }
         return problems;
     }
@@ -359,7 +407,7 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
     }
 
     private List<Throwable> doAnyDiscovery(AbstractInvocationContext context, final FilterSpec filterSpec, final EJBLocator<?> locator) {
-        Logs.INVOCATION.tracef("Performing any discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
+        Logs.INVOCATION.tracef("DiscoveryEJBClientInterceptor: performing any discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
         final List<Throwable> problems;
         // blacklist
         final Set<URI> blacklist = context.getAttachment(BL_KEY);
@@ -416,7 +464,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
 
         if (nodes.isEmpty()) {
             // no match
-            Logs.INVOCATION.tracef("Performed any discovery, no match");
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed any discovery, no match");
+            }
             return problems;
         }
         URI location;
@@ -425,7 +475,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             final Map.Entry<URI, String> entry = nodes.entrySet().iterator().next();
             location = entry.getKey();
             nodeName = entry.getValue();
-            Logs.INVOCATION.tracef("Performed first-match discovery(target affinity(node) = %s, destination = %s)", nodeName, location);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed any discovery(target affinity(node) = %s, destination = %s)", nodeName, location);
+            }
         } else if (nodeless == 0) {
             // use the deployment node selector
             DeploymentNodeSelector selector = context.getClientContext().getDeploymentNodeSelector();
@@ -437,7 +489,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             if (location == null) {
                 throw Logs.INVOCATION.selectorReturnedUnknownNode(selector, nodeName);
             }
-            Logs.INVOCATION.tracef("Performed first-match discovery, nodes > 1, deployment selector used(target affinity(node) = %s, destination = %s)", nodeName, location);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed any discovery, nodes > 1, deployment selector used(target affinity(node) = %s, destination = %s)", nodeName, location);
+            }
         } else {
             // todo: configure on client context
             DiscoveredURISelector selector = DiscoveredURISelector.RANDOM;
@@ -449,7 +503,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             if (nodeName == null) {
                 throw Logs.INVOCATION.selectorReturnedUnknownNode(selector, location.toString());
             }
-            Logs.INVOCATION.tracef("Performed first-match discovery, nodes > 1, URI selector used(target affinity(node) = %s, destination = %s)", nodeName, location);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed any discovery, nodes > 1, URI selector used(target affinity(node) = %s, destination = %s)", nodeName, location);
+            }
         }
 
         // TODO DeploymentNodeSelector should be enhanced to handle URIs that are members of more than one cluster
@@ -478,7 +534,7 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
     }
 
     private List<Throwable> doClusterDiscovery(AbstractInvocationContext context, final FilterSpec filterSpec) {
-        Logs.INVOCATION.tracef("Performing cluster discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
+        Logs.INVOCATION.tracef("DiscoveryEJBClientInterceptor: performing cluster discovery(locator = %s, weak affinity = %s, filter spec = %s)", context.getLocator(), context.getWeakAffinity(), filterSpec);
         Map<String, URI> nodes = new HashMap<>();
         final EJBClientContext clientContext = context.getClientContext();
         final List<Throwable> problems;
@@ -510,8 +566,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         final EJBLocator<?> locator = context.getLocator();
 
         if (nodes.isEmpty()) {
-
-            Logs.INVOCATION.tracef("Performed cluster discovery, nodes is empty; trying an initial ");
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed cluster discovery, nodes is empty; trying an initial ");
+            }
 
             final NamingProvider namingProvider = context.getAttachment(Keys.NAMING_PROVIDER_ATTACHMENT_KEY);
             if (namingProvider != null) {
@@ -527,7 +584,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             context.setTargetAffinity(new NodeAffinity(nodeName));
             context.setDestination(uri);
 
-            Logs.INVOCATION.tracef("Performed cluster discovery (target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed cluster discovery, single node case (target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+            }
 
             return problems;
         }
@@ -545,10 +604,17 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                 }
             }
         }
-        Logs.INVOCATION.tracef("Performing cluster discovery (connected nodes = %s, available nodes = %s)", connectedNodes, availableNodes);
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performing cluster discovery, multi node case (connected nodes = %s, available nodes = %s)", connectedNodes, availableNodes);
+        }
 
         final ClusterNodeSelector selector = clientContext.getClusterNodeSelector();
         final String selectedNode = selector.selectNode(((ClusterAffinity) locator.getAffinity()).getClusterName(), connectedNodes.toArray(NO_STRINGS), availableNodes.toArray(NO_STRINGS));
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performing cluster discovery, multi-node case (cluster node selector = %s, selected node = %s)", selector.getClass().getName(), selectedNode);
+        }
+
         if (selectedNode == null) {
             throw withSuppressed(Logs.MAIN.selectorReturnedNull(selector), problems);
         }
@@ -560,7 +626,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         context.setDestination(uri);
         context.setTargetAffinity(new NodeAffinity(selectedNode));
 
-        Logs.INVOCATION.tracef("Performed cluster discovery (target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: performed cluster discovery (target affinity = %s, destination = %s)", context.getTargetAffinity(), context.getDestination());
+        }
 
         return problems;
     }

--- a/src/main/java/org/jboss/ejb/client/EJBClient.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClient.java
@@ -199,6 +199,10 @@ public final class EJBClient {
         final T proxy = createProxy(statefulLocator, authenticationContextSupplier);
         final Affinity weakAffinity = context.getWeakAffinity();
 
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("createSessionProxy: strong affinity = %s, weak affinity = %s", statefulLocator.getAffinity(), context.getWeakAffinity());
+        }
+
         if (weakAffinity != null && Affinity.NONE != weakAffinity) {
             setWeakAffinity(proxy, weakAffinity);
         }

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -825,7 +825,9 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         // Special hook for naming; let's replace this sometime soon.
         if (namingProvider != null) context.putAttachment(Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
 
-        Logs.INVOCATION.tracef("Calling createSession(locator = %s)",statelessLocator);
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("Calling createSession(locator = %s)", statelessLocator);
+        }
 
         SessionID sessionID = null;
         for (int i = 0; i < MAX_SESSION_RETRIES; i++) {
@@ -855,9 +857,15 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
             if (i == MAX_SESSION_RETRIES - 1) {
                 throw new RequestSendFailedException(t.getMessage() + " (maximum retries exceeded)", t);
             }
-            Logs.INVOCATION.tracef("Retrying invocation (attempt %d): %s", i + 1, statelessLocator);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("Retrying invocation (attempt %d): %s", i + 1, statelessLocator);
+            }
         }
         final Affinity affinity = context.getLocator().getAffinity();
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("Session created: session id: %s , affinity: %s", sessionID, affinity);
+        }
 
         return statelessLocator.withSessionAndAffinity(sessionID, affinity);
     }

--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -460,6 +460,10 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 final URI destination = getDestination();
                 final EJBReceiver receiver;
                 try {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("sendRequest: setting receiver, strong affinity = %s, weak affinity = %s, remote destination is: %s",
+                                getLocator().getAffinity(), invocationHandler.getWeakAffinity(), destination);
+                    }
                     receiver = getClientContext().resolveReceiver(destination, getLocator());
                 } catch (Throwable t) {
                     synchronized (lock) {
@@ -488,6 +492,9 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 }
             } else {
                 try {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("sendRequest: calling interceptor: %s", chain[idx].getInterceptorInstance());
+                    }
                     chain[idx].getInterceptorInstance().handleInvocation(this);
                 } catch (Throwable t) {
                     synchronized (lock) {
@@ -643,6 +650,9 @@ public final class EJBClientInvocationContext extends AbstractInvocationContext 
                 throw t;
             } finally {
                 if (idx == 0) {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("getResult(): invocation returned, relocating EJB: strong affinity = %s, weak affinity = %s", getLocator().getAffinity(), getWeakAffinity());
+                    }
                     // relocate the EJB
                     invocationHandler.setWeakAffinity(getWeakAffinity());
                     invocationHandler.setStrongAffinity(getLocator().getAffinity());

--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -86,6 +86,10 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
         if (locator instanceof StatefulEJBLocator) {
             // set the weak affinity to the node on which the session was created
             setWeakAffinity(locator.getAffinity());
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("EJBInvocationHandler: setting weak affinity = %s", locator.getAffinity());
+            }
         }
     }
 
@@ -103,6 +107,10 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
         if (locator instanceof StatefulEJBLocator) {
             // set the weak affinity to the node on which the session was created
             setWeakAffinity(locator.getAffinity());
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("EJBInvocationHandler(constructor): setting weak affinity = %s", locator.getAffinity());
+            }
         }
     }
 

--- a/src/main/java/org/jboss/ejb/client/EJBRootContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBRootContext.java
@@ -154,11 +154,17 @@ class EJBRootContext extends AbstractContext {
         final Object proxy;
         if (stateful) {
             try {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("lookupNative: createSessionProxy, locator = %s, baseAffinity = %s", statelessLocator, baseAffinity.get());
+                }
                 proxy = EJBClient.createSessionProxy(statelessLocator, providerEnvironment.getAuthenticationContextSupplier(), namingProvider);
             } catch (Exception e) {
                 throw Logs.MAIN.lookupFailed(name, name, e);
             }
         } else {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("lookupNative: createProxy, locator = %s", statelessLocator);
+            }
             proxy = EJBClient.createProxy(statelessLocator, providerEnvironment.getAuthenticationContextSupplier());
         }
         if (namingProvider != null) EJBClient.putProxyAttachment(proxy, Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
@@ -171,6 +177,10 @@ class EJBRootContext extends AbstractContext {
         Long invocationTimeout = getLongValueFromEnvironment(PROPERTY_KEY_INVOCATION_TIMEOUT);
         if (invocationTimeout != null) {
             EJBClient.setInvocationTimeout(proxy, invocationTimeout.longValue(), TimeUnit.MILLISECONDS);
+        }
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("lookupNative: created proxy, locator = %s, weakAffinity = %s", EJBClient.getLocatorFor(proxy), EJBClient.getWeakAffinity(proxy));
         }
 
         return proxy;

--- a/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
@@ -59,6 +59,9 @@ public final class EJBSessionCreationInvocationContext extends AbstractInvocatio
             if (chain.length == idx) {
                 final URI destination = getDestination();
                 final EJBReceiver receiver = getClientContext().resolveReceiver(destination, getLocator());
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("session creation proceed(): setting receiver, remote destination is: %s", destination);
+                }
                 setReceiver(receiver);
                 final SessionID sessionID = receiver.createSession(new EJBReceiverSessionCreationContext(this, authenticationContext));
                 if (sessionID == null) {
@@ -67,6 +70,9 @@ public final class EJBSessionCreationInvocationContext extends AbstractInvocatio
                 retry = false;
                 return sessionID;
             } else {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("session creation proceed(): calling interceptor: %s", chain[idx].getInterceptorInstance());
+                }
                 return chain[idx].getInterceptorInstance().handleSessionCreation(this);
             }
         } finally {

--- a/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
@@ -60,9 +60,15 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             context.putAttachment(Keys.NAMING_PROVIDER_ATTACHMENT_KEY, namingProvider);
         }
         if (namingProvider == null || context.getDestination() != null || context.getLocator().getAffinity() != Affinity.NONE) {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling handleInvocation: skipping missing target");
+            }
             context.putAttachment(SKIP_MISSING_TARGET, Boolean.TRUE);
             context.sendRequest();
         } else {
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling handleInvocation: setting destination");
+            }
             if (setDestination(context, namingProvider)) try {
                 context.sendRequest();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -138,8 +144,12 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
     static boolean setNamingDestination(final AbstractInvocationContext context, final NamingProvider namingProvider) {
         final ProviderEnvironment providerEnvironment = namingProvider.getProviderEnvironment();
         final List<URI> providerUris = providerEnvironment.getProviderUris();
-
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: calling setNamingDestination: providerURIs = %s, invocationContext type = %s", providerUris.toString(), context.getClass().getName());
+        }
+        // select the subset of providerURIs that agree with TransactionInterceptor's choices
         List<URI> uris = findPreferredURIs(context, providerUris);
+        // if there are none, use all non-blacklisted providerURIs instead
         if (uris == null) {
             uris = new ArrayList<>(providerUris.size());
             for (URI uri : providerUris) {
@@ -155,9 +165,15 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             return false;
         } else if (size == 1) {
             context.setDestination(uris.get(0));
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: setting destination: (size == 1), destination = %s", context.getDestination());
+            }
             return true;
         } else {
             context.setDestination(uris.get(ThreadLocalRandom.current().nextInt(size)));
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: setting destination: (size > 1), destination = %s", context.getDestination());
+            }
         }
 
         if (context instanceof EJBSessionCreationInvocationContext) {
@@ -183,6 +199,9 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
                 result.add(check);
             }
         }
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: computing preferred URIs: URIs = %s, preferred URIs = %s", uris, result);
+        }
 
         return result;
     }
@@ -194,6 +213,10 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
             return;
         }
 
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: missing target, *** retrying ***: locator = %s", context.getLocator());
+        }
+
         // Oops, we got some wrong information!
         addBlackListedDestination(context, destination);
 
@@ -201,6 +224,11 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
         if (! (locator.getAffinity() instanceof ClusterAffinity)) {
             // it *was* "none" affinity, but it has been relocated; locate it back again
             context.setLocator(locator.withNewAffinity(Affinity.NONE));
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("NamingEJBClientInterceptor: resetting strong affinity = %s", context.getLocator().getAffinity());
+            }
+
         }
         // clear the weak affinity so that cluster invocations can be re-targeted.
         context.setWeakAffinity(Affinity.NONE);

--- a/src/main/java/org/jboss/ejb/client/TransactionPostDiscoveryInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/TransactionPostDiscoveryInterceptor.java
@@ -63,6 +63,9 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (applications != null) {
             URI destination = context.getDestination();
             Application registered = updateOrFollowApplication(context, applications, true);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling handleInvocation, destination = %s, application = %s", destination, registered);
+            }
             try {
                 context.sendRequest();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -85,6 +88,9 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (applications != null) {
             URI destination = context.getDestination();
             Application registered = updateOrFollowApplication(context, applications, false);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling handleSessionCreation, destination = %s, application = %s", destination, registered);
+            }
             try {
                 return context.proceed();
             } catch (NoSuchEJBException | RequestSendFailedException e) {
@@ -107,12 +113,21 @@ public final class TransactionPostDiscoveryInterceptor implements EJBClientInter
         if (destination != null) {
             EJBIdentifier identifier = context.getLocator().getIdentifier();
             Application application = toApplication(identifier);
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, destination = %s, application = %s", destination, application);
+            }
             URI existing = applications.putIfAbsent(application, destination);
             if (existing != null) {
+                if (Logs.INVOCATION.isDebugEnabled()) {
+                    Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, updating from map, destination = %s", existing);
+                }
                 // Someone else set a mapping, use it instead
                 context.setDestination(existing);
             } else {
                 if (register) {
+                    if (Logs.INVOCATION.isDebugEnabled()) {
+                        Logs.INVOCATION.debugf("TransactionPostDiscoveryInterceptor: calling updateOrFollowApplication, added destination for application, application = %s", application);
+                    }
                     context.putAttachment(APPLICATION, application);
                 }
 

--- a/src/main/java/org/jboss/ejb/client/URIAffinity.java
+++ b/src/main/java/org/jboss/ejb/client/URIAffinity.java
@@ -36,7 +36,7 @@ public final class URIAffinity extends Affinity {
      *
      * @param uri the URI to bind to (must not be {@code null})
      */
-    URIAffinity(final URI uri) {
+    public URIAffinity(final URI uri) {
         if (uri == null) {
             throw new IllegalArgumentException("URI is null");
         }

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -180,6 +180,7 @@ public class TransactionTestCase {
         HashSet<String> ids = new HashSet<>();
 
         for (int attempts = 0; attempts < 40; attempts++) {
+            System.out.println("\n *** Starting transaction # " + attempts + " ***\n");
             transaction.begin();
             HashMap<String, Integer> replies = new HashMap<>();
             String id = null;
@@ -196,6 +197,7 @@ public class TransactionTestCase {
             Assert.assertEquals(1, replies.size());
             Assert.assertEquals(20, replies.values().iterator().next().intValue());
             ids.add(id);
+            System.out.println("\n*** Committing transaction # " + attempts + " ***\n");
             transaction.commit();
         }
 


### PR DESCRIPTION
This PR addresses a problem in affinity processing with the EJB client when the NamingEJBClientInterceptor is used to discover a destination for an invocation.

See the issue for more details: https://issues.jboss.org/browse/EJBCLIENT-319
It is required for the changes in https://issues.jboss.org/browse/WFLY-11489