### PR TITLE
Testsuite enhancements for validating affinity processing

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -120,6 +120,11 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         try {
             result = context.getResult();
         } catch (NoSuchEJBException | RequestSendFailedException e) {
+
+            if (Logs.INVOCATION.isDebugEnabled()) {
+                Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: handleInvocationResult: (exception = %s)", e.getMessage());
+            }
+
             processMissingTarget(context);
             throw e;
         }

--- a/src/test/java/org/jboss/ejb/client/test/AbstractEJBClientTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/AbstractEJBClientTestCase.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.ejb.client.test;
+
+import org.jboss.ejb.client.EJBIdentifier;
+import org.jboss.ejb.client.EJBModuleIdentifier;
+import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.StatefulEchoBean;
+import org.jboss.ejb.client.test.common.StatelessEchoBean;
+import org.jboss.ejb.server.ClusterTopologyListener;
+import org.jboss.logging.Logger;
+
+/**
+ * A base class for EJB client test cases.
+ *
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class AbstractEJBClientTestCase {
+
+    private static final Logger logger = Logger.getLogger(AbstractEJBClientTestCase.class);
+
+    // servers
+    public static final String SERVER1_NAME = "node1";
+    public static final String SERVER2_NAME = "node2";
+    public static final String SERVER3_NAME = "node3";
+    public static final String SERVER4_NAME = "node4";
+
+    public static String[] serverNames = {SERVER1_NAME, SERVER2_NAME, SERVER3_NAME, SERVER4_NAME};
+    public static final int NUM_SERVERS = 4;
+    public DummyServer[] servers = new DummyServer[NUM_SERVERS];
+    public boolean[] serversStarted = new boolean[NUM_SERVERS] ;
+
+    // module
+    public static final String APP_NAME = "my-foo-app";
+    public static final String OTHER_APP = "my-other-app";
+    public static final String MODULE_NAME = "my-bar-module";
+    public static final String DISTINCT_NAME = "";
+
+    // cluster
+    // note: node names and server names should match!
+    public static final String CLUSTER_NAME = "ejb";
+    public static final String NODE1_NAME = "node1";
+    public static final String NODE2_NAME = "node2";
+    public static final String NODE3_NAME = "node3";
+    public static final String NODE4_NAME = "node4";
+
+    public static final ClusterTopologyListener.NodeInfo NODE1 = DummyServer.getNodeInfo(NODE1_NAME, "localhost",6999,"0.0.0.0",0);
+    public static final ClusterTopologyListener.NodeInfo NODE2 = DummyServer.getNodeInfo(NODE2_NAME, "localhost",7099,"0.0.0.0",0);
+    public static final ClusterTopologyListener.NodeInfo NODE3 = DummyServer.getNodeInfo(NODE3_NAME, "localhost",7199,"0.0.0.0",0);
+    public static final ClusterTopologyListener.NodeInfo NODE4 = DummyServer.getNodeInfo(NODE4_NAME, "localhost",7299,"0.0.0.0",0);
+    public static final ClusterTopologyListener.ClusterInfo CLUSTER = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
+
+    // convenience
+    public final EJBModuleIdentifier MODULE_IDENTIFIER = new EJBModuleIdentifier(APP_NAME, MODULE_NAME, DISTINCT_NAME);
+    public final EJBModuleIdentifier OTHER_MODULE_IDENTIFIER = new EJBModuleIdentifier(OTHER_APP, MODULE_NAME, DISTINCT_NAME);
+    public final EJBIdentifier STATELESS_IDENTIFIER = new EJBIdentifier(MODULE_IDENTIFIER,StatelessEchoBean.class.getSimpleName());
+    public final EJBIdentifier STATEFUL_IDENTIFIER = new EJBIdentifier(MODULE_IDENTIFIER,StatefulEchoBean.class.getSimpleName());
+
+
+    public void startServer(int index, int port) throws Exception {
+        startServer(index, port, false);
+    }
+
+    public void startServer(int index, int port, boolean startTxService) throws Exception {
+        servers[index] = new DummyServer("localhost", port, serverNames[index], startTxService);
+        servers[index].start();
+        serversStarted[index] = true;
+        logger.info("Started server " + serverNames[index] + (startTxService ? " with transaction service" : ""));
+    }
+
+    public void stopServer(int index) {
+        if (isServerStarted(index)) {
+            try {
+                this.servers[index].stop();
+            } catch (Throwable t) {
+                logger.info("Could not stop server " + serverNames[index], t);
+            }
+        }
+        logger.info("Stopped server " + serverNames[index]);
+    }
+
+    public boolean isServerStarted(int index) {
+        return serversStarted[index];
+    }
+
+    public void deployStateless(int index) {
+        servers[index].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatelessEchoBean.class.getSimpleName(), new StatelessEchoBean(serverNames[index]));
+        logger.info("Registered SLSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void undeployStateless(int index) {
+        servers[index].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatelessEchoBean.class.getSimpleName());
+        logger.info("Unregistered SLSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void deployStateful(int index) {
+        servers[index].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatefulEchoBean.class.getSimpleName(), new StatefulEchoBean(serverNames[index]));
+        logger.info("Registered SFSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void undeployStateful(int index) {
+        servers[index].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatefulEchoBean.class.getSimpleName());
+        logger.info("Unregistered SFSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void defineCluster(int index, ClusterTopologyListener.ClusterInfo cluster) {
+        servers[index].addCluster(cluster);
+        logger.info("Added node to cluster " + cluster + ": server " + servers[index]);
+    }
+
+    public void removeCluster(int index, String clusterName) {
+        servers[index].removeCluster(clusterName);
+        logger.info("Removed cluster " + clusterName + " from node: server " + servers[index]);
+    }
+
+    public void deployOtherStateless(int index) {
+        servers[index].register(OTHER_APP, MODULE_NAME, DISTINCT_NAME, StatelessEchoBean.class.getSimpleName(), new StatelessEchoBean(serverNames[index]));
+        logger.info("Registered other SLSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void undeployOtherStateless(int index) {
+        servers[index].unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, StatelessEchoBean.class.getSimpleName());
+        logger.info("Unregistered other SLSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void deployOtherStateful(int index) {
+        servers[index].register(OTHER_APP, MODULE_NAME, DISTINCT_NAME, StatefulEchoBean.class.getSimpleName(), new StatefulEchoBean(serverNames[index]));
+        logger.info("Registered other SFSB module " + OTHER_MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void undeployOtherStateful(int index) {
+        servers[index].unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, StatefulEchoBean.class.getSimpleName());
+        logger.info("Unregistered other SFSB module " + OTHER_MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
+    }
+
+    public void deployCustomBean(int index, String app, String module, String distinct, String beanName, Object beanInstance) {
+        servers[index].register(app, module, distinct, beanName, beanInstance);
+        logger.info("Registered custom bean " + (new EJBModuleIdentifier(app, module, distinct)).toString()  + " on server " + serverNames[index]);
+    }
+
+    public void undeployCustomBean(int index, String app, String module, String distinct, String beanName) {
+        servers[index].unregister(app, module, distinct, beanName);
+        logger.info("Unregistered custom bean " + (new EJBModuleIdentifier(app, module, distinct)).toString()  + " on server " + serverNames[index]);
+    }
+
+}

--- a/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationTestCase.java
@@ -17,17 +17,23 @@
  */
 package org.jboss.ejb.client.test;
 
+import org.jboss.ejb.client.Affinity;
 import org.jboss.ejb.client.ClusterAffinity;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.ejb.client.EJBClientCluster;
 import org.jboss.ejb.client.EJBClientConnection;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.StatefulEJBLocator;
+import org.jboss.ejb.client.EJBIdentifier;
+import org.jboss.ejb.client.EJBModuleIdentifier;
+import org.jboss.ejb.client.NodeAffinity;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.ejb.client.legacy.JBossEJBProperties;
 import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.Echo;
 import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.ejb.client.test.common.Result;
+import org.jboss.ejb.client.test.common.StatefulEchoBean;
+import org.jboss.ejb.client.test.common.StatelessEchoBean;
 import org.jboss.ejb.server.ClusterTopologyListener.ClusterInfo;
 import org.jboss.ejb.server.ClusterTopologyListener.NodeInfo;
 import org.jboss.logging.Logger;
@@ -38,45 +44,24 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.wildfly.common.context.ContextManager;
-import org.wildfly.common.context.Contextual;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 
 /**
- * Tests basic invocation of a bean deployed on a single server node.
+ * Tests basic features of proxies for invocation of a bean deployed on clustered server nodes.
+ *
+ * The server environment consists of two clustered nodes and one singleton node:
+ * on node1: bean Echo is deployed, clustered
+ * on node2: bean Echo is deployed, clustered
+ * on node3: bean Echo is deployed, non-clustered
  *
  * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
-public class ClusteredInvocationTestCase {
+public class ClusteredInvocationTestCase extends AbstractEJBClientTestCase{
 
     private static final Logger logger = Logger.getLogger(ClusteredInvocationTestCase.class);
     private static final String PROPERTIES_FILE = "clustered-jboss-ejb-client.properties";
-
-    // servers
-    private static final String SERVER1_NAME = "node1";
-    private static final String SERVER2_NAME = "node2";
-
-    private DummyServer[] servers = new DummyServer[2];
-    private static String[] serverNames = {SERVER1_NAME, SERVER2_NAME};
-    private boolean[] serversStarted = new boolean[2] ;
-
-    // module
-    private static final String APP_NAME = "my-foo-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    // cluster
-    // note: node names and server names should match!
-    private static final String CLUSTER_NAME = "ejb";
-    private static final String NODE1_NAME = "node1";
-    private static final String NODE2_NAME = "node2";
-
-    private static final NodeInfo NODE1 = DummyServer.getNodeInfo(NODE1_NAME, "localhost",6999,"0.0.0.0",0);
-    private static final NodeInfo NODE2 = DummyServer.getNodeInfo(NODE2_NAME, "localhost",7099,"0.0.0.0",0);
-    private static final ClusterInfo CLUSTER = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
 
     /**
      * Do any general setup here
@@ -98,38 +83,30 @@ public class ClusteredInvocationTestCase {
     @Before
     public void beforeTest() throws Exception {
 
-        // start a server
-        servers[0] = new DummyServer("localhost", 6999, serverNames[0]);
-        servers[0].start();
-        serversStarted[0] = true;
-        logger.info("Started server " + serverNames[0]);
-
-        // start a server
-        servers[1] = new DummyServer("localhost", 7099, serverNames[1]);
-        servers[1].start();
-        serversStarted[1] = true;
-        logger.info("Started server " + serverNames[1]);
-
-        // deploy modules
-        servers[0].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
-        logger.info("Registered module on server " + servers[0]);
-
-        servers[1].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
-        logger.info("Registered module on server " + servers[1]);
+        // start servers
+        for (int i = 0; i < 3; i++) {
+            startServer(i, 6999 + (i * 100));
+            deployStateful(i);
+            deployStateless(i);
+        }
 
         // define clusters
-        servers[0].addCluster(CLUSTER);
-        logger.info("Added node to cluster " + CLUSTER_NAME + ": server " + servers[1]);
-        servers[1].addCluster(CLUSTER);
-        logger.info("Added node to cluster " +  CLUSTER_NAME +":  server " + servers[1]);
+        defineCluster(0, CLUSTER);
+        defineCluster(1, CLUSTER);
+        // don't add node3 to the cluster; it's a singleton node
     }
 
+    /**
+     * Test number of configured connections in EJBClientContext.
+     */
     @Test
     public void testConfiguredConnections() {
+        logger.info("=== Testing configured connections ===");
+
         EJBClientContext context = EJBClientContext.getCurrent();
         List<EJBClientConnection> connections = context.getConfiguredConnections();
 
-        Assert.assertEquals("Number of configured connections for this context is incorrect", 2, connections.size());
+        Assert.assertEquals("Number of configured connections for this context is incorrect", 3, connections.size());
         for (EJBClientConnection connection : connections) {
             logger.info("found connection: destination = " + connection.getDestination() + ", forDiscovery = " + connection.isForDiscovery());
         }
@@ -141,58 +118,316 @@ public class ClusteredInvocationTestCase {
     }
 
     /**
-     * Test a basic invocation on clustered SLSB
+     * Test SFSB default proxy initialization (legacy behaviour)
+     *
+     * scenario:
+     *   invoked bean available on both nodes of the cluster "ejb" = {node1, node2}, not available on non-clustered node3
+     *   accept default affinities (simulated here by setting strong affinity = NONE)
+     * expected result:
+     *   SFSB session is created on node 'node' of the cluster, strong affinity = ClusterAffinity("ejb"), weakAffinity = NodeAffinity(node)
      */
     @Test
-    public void testClusteredSLSBInvocation() {
-        logger.info("Testing invocation on SLSB proxy with ClusterAffinity");
+    public void testSFSBDefaultProxyInitialization() {
+        logger.info("=== Testing default proxy initialization for SFSB proxy with ClusterAffinity ===");
 
-        // create a proxy for invocation
-        final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
-        final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+        Affinity expectedWeakAffinity1 = new NodeAffinity(serverNames[0]);
+        Affinity expectedWeakAffinity2 = new NodeAffinity(serverNames[1]);
 
-        EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
+        // remove the singleton from the environment
+        undeployStateful(2);
+
+        // create a SFSB proxy with default affinity
+        final StatelessEJBLocator<Echo> statefulEJBLocator = StatelessEJBLocator.create(Echo.class, STATEFUL_IDENTIFIER, Affinity.NONE);
+        Echo proxy ;
+        try {
+            proxy = EJBClient.createSessionProxy(statefulEJBLocator);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception when creating session proxy: e = " + e.getMessage());
+            proxy = null;
+        }
         Assert.assertNotNull("Received a null proxy", proxy);
         logger.info("Created proxy for Echo: " + proxy.toString());
 
-        logger.info("Invoking on proxy...");
-        // invoke on the proxy (use a ClusterAffinity for now)
-        final String message = "hello!";
-         String echo = null;
-        for (int i = 0; i < 10; i++) {
-           echo = proxy.echo(message);
-        }
-        Assert.assertEquals("Got an unexpected echo", echo, message);
+        // check affinity assignment
+        Affinity strongAffinity = EJBClient.getStrongAffinity(proxy);
+        Affinity weakAffinity = EJBClient.getWeakAffinity(proxy);
+        Assert.assertEquals("Got an unexpected strong affinity", expectedStrongAffinity , strongAffinity);
+        Assert.assertTrue("Got an unexpected weak affinity", weakAffinity.equals(expectedWeakAffinity1) || weakAffinity.equals(expectedWeakAffinity2));
+
+        // add back the singleton from the environment
+        deployStateful(2);
     }
 
     /**
-     * Test a basic invocation on clustered SFSB
+     * Test SFSB programmatic proxy initialization
+     *
+     * scenario:
+     *   invoked bean available on both nodes of the cluster "ejb" = {node1, node2}, also available on non-clustered node3
+     * expected result:
+     *   SFSB session is created on node 'node' of the cluster, strong affinity = ClusterAffinity("ejb"), weakAffinity = NodeAffinity(node)
      */
-    @Test
-    public void testClusteredSFSBInvocation() throws Exception {
-        logger.info("Testing invocation on SFSB proxy with ClusterAffinity");
+   @Test
+    public void testSFSBProgrammaticProxyInitialization() {
+        logger.info("=== Testing programmatic proxy initialization for SFSB proxy with ClusterAffinity ===");
 
-        // create a proxy for invocation
-        final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
-        StatefulEJBLocator<Echo> statefulEJBLocator = null;
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+        Affinity expectedWeakAffinity1 = new NodeAffinity(serverNames[0]);
+        Affinity expectedWeakAffinity2 = new NodeAffinity(serverNames[1]);
+
+        // create a SFSB proxy with default affinity
+        final StatelessEJBLocator<Echo> statefulEJBLocator = StatelessEJBLocator.create(Echo.class, STATEFUL_IDENTIFIER, expectedStrongAffinity);
+        Echo proxy ;
         try {
-            statefulEJBLocator = EJBClient.createSession(statelessEJBLocator);
-        } catch(Exception e) {
-            logger.warn("Got exception", e);
-            throw e;
+            proxy = EJBClient.createSessionProxy(statefulEJBLocator);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception when creating session proxy: e = " + e.getMessage());
+            proxy = null;
         }
-
-        final Echo proxy = EJBClient.createProxy(statefulEJBLocator);
-
-        EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
         Assert.assertNotNull("Received a null proxy", proxy);
         logger.info("Created proxy for Echo: " + proxy.toString());
 
+        // check affinity assignment
+        Affinity strongAffinity = EJBClient.getStrongAffinity(proxy);
+        Affinity weakAffinity = EJBClient.getWeakAffinity(proxy);
+        Assert.assertEquals("Got an unexpected strong affinity", expectedStrongAffinity , strongAffinity);
+        Assert.assertTrue("Got an unexpected weak affinity", weakAffinity.equals(expectedWeakAffinity1) || weakAffinity.equals(expectedWeakAffinity2));
+    }
+
+
+    /**
+     * Test a basic invocation on clustered SFSB
+     *
+     * scenario:
+     *   invoked bean available on three nodes, non-clustered node3, and cluster "ejb" = {node1, node2}
+     *   proxy has cluster affinity
+     * expected result:
+     *   SFSB session is created on a node 'node' in the cluster, strong affinity = ClusterAffinity("ejb"), weakAffinity = NodeAffinity("node")
+     *   the first invocation arrives at the node the session was created on
+     *   the second invocation arrives at the same node
+     */
+    @Test
+    public void testClusteredSFSBInvocation() throws Exception {
+        logger.info("=== Testing invocation on SFSB proxy with ClusterAffinity ===");
+
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+        Affinity expectedWeakAffinity1 = new NodeAffinity(serverNames[0]);
+        Affinity expectedWeakAffinity2 = new NodeAffinity(serverNames[1]);
+
+        // create a proxy for invocation
+       final StatelessEJBLocator<Echo> statelessEJBLocator = StatelessEJBLocator.create(Echo.class, STATEFUL_IDENTIFIER, expectedStrongAffinity);
+       Echo proxy;
+        try {
+            proxy = EJBClient.createSessionProxy(statelessEJBLocator);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception when creating session proxy: e = " + e.getMessage());
+            proxy = null;
+        }
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        // remember the node the session was created on
+        Affinity weakAffinity = EJBClient.getWeakAffinity(proxy);
+        Assert.assertTrue("Expected weak affinity to have NodeAffinity!", weakAffinity instanceof NodeAffinity);
+        String target = ((NodeAffinity)weakAffinity).getNodeName();
+        Assert.assertTrue("Session not created on cluster node!", target.equals(serverNames[0]) || target.equals(serverNames[1]));
+
+        // invoke on the proxy
         logger.info("Invoking on proxy...");
-        // invoke on the proxy (use a ClusterAffinity for now)
         final String message = "hello!";
-        final String echo = proxy.echo(message);
-        Assert.assertEquals("Got an unexpected echo", echo, message);
+        Result<String> echoResult = proxy.echo(message);
+        logger.info("Clustered SFSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(target));
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...again");
+        echoResult = proxy.echo(message);
+        logger.info("Clustered SFSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(target));
+
+    }
+
+    /**
+     * Test a basic invocation on non-clustered SFSB
+     */
+    @Test
+    public void testNonClusteredSFSBInvocation() throws Exception {
+        logger.info("=== Testing invocation on SFSB proxy with NodeAffinity ===");
+
+        Affinity expectedStrongAffinity = new NodeAffinity("node3");
+
+        // create a proxy for invocation
+        final StatelessEJBLocator<Echo> statelessEJBLocator = StatelessEJBLocator.create(Echo.class, STATEFUL_IDENTIFIER, expectedStrongAffinity);
+        Echo proxy;
+        try {
+            proxy = EJBClient.createSessionProxy(statelessEJBLocator);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception when creating session proxy: e = " + e.getMessage());
+            proxy = null;
+        }
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...");
+        final String message = "hello!";
+        final Result<String> echoResult = proxy.echo(message);
+
+        // check message contents and target
+        logger.info("Non-clustered SFSB invocation had target " + echoResult.getNode());
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(serverNames[2]));
+    }
+
+    /**
+     * Test invocation on clustered SFSB with failover
+     *
+     * scenario:
+     *   invoked bean available on three nodes, non-clustered node3, and cluster "ejb" = {node1, node2}
+     *   proxy has cluster affinity
+     * expected result:
+     *   SFSB session is created on a node 'node' in the cluster, strong affinity = ClusterAffinity("ejb"), weakAffinity = NodeAffinity("node")
+     *   the first invocation arrives at the node the session was created on
+     *   undeploy the bean from that node
+     *   the second invocation arrives at the other node, having successfully failed over
+     */
+    @Test
+    public void testClusteredSFSBInvocationWithFailover() throws Exception {
+        logger.info("=== Testing invocation on SFSB proxy with ClusterAffinity ===");
+
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+
+        // create a proxy for invocation
+        final StatelessEJBLocator<Echo> statelessEJBLocator = StatelessEJBLocator.create(Echo.class, STATEFUL_IDENTIFIER, expectedStrongAffinity);
+        Echo proxy;
+        try {
+            proxy = EJBClient.createSessionProxy(statelessEJBLocator);
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception when creating session proxy: e = " + e.getMessage());
+            proxy = null;
+        }
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        // remember the node the session was created on
+        Affinity weakAffinity = EJBClient.getWeakAffinity(proxy);
+        Assert.assertTrue("Expected weak affinity to have NodeAffinity!", weakAffinity instanceof NodeAffinity);
+        String target = ((NodeAffinity)weakAffinity).getNodeName();
+        Assert.assertTrue("Session not created on cluster node!", target.equals(serverNames[0]) || target.equals(serverNames[1]));
+
+        // calculate the failover node and the index of the node the session resides on
+        String failoverNode = target == "node1" ? "node2" : "node1";
+        int sessionNodeIndex = target == "node1" ? 0 : 1;
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...");
+        final String message = "hello!";
+        Result<String> echoResult = proxy.echo(message);
+        logger.info("Clustered SFSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(target));
+
+        undeployStateful(sessionNodeIndex);
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...again");
+        echoResult = proxy.echo(message);
+        logger.info("Clustered SFSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(failoverNode));
+
+        deployStateful(sessionNodeIndex);
+    }
+
+
+    /**
+     * Test a basic invocation on a clustered SLSB
+     *
+     * scenario:
+     *   invoked bean available on three nodes, cluster "ejb" = {node1, node2}, non-clustered node node3
+     *   proxy has cluster affinity to cluster "ejb"
+     * expected result:
+     *   SLSB invocation occurs on one of the two cluster nodes
+     */
+    @Test
+    public void testClusteredSLSBInvocation() {
+        logger.info("=== Testing invocation on SLSB proxy with ClusterAffinity ===");
+
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+
+        // create a proxy for invocation
+        final StatelessEJBLocator<Echo> statelessEJBLocator = StatelessEJBLocator.create(Echo.class, STATELESS_IDENTIFIER, expectedStrongAffinity);
+        final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...");
+        final String message = "hello!";
+        final Result<String> echoResult = proxy.echo(message);
+
+        // check message contents and target
+        logger.info("Clustered SLSB invocation had target " + echoResult.getNode());
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(serverNames[0]) || echoResult.getNode().equals(serverNames[1]));
+    }
+
+    /**
+     * Test SLSB invocation with failed node
+     *
+     * scenario:
+     *   invoked bean available on clustered nodes, node1 and node2, as well as non-clustered node, node3
+     *   strong affinity is set to ClusterAffinity("ejb")
+     *   invoke on the proxy
+     *   undeploy the bean from node1
+     *   invoke on the proxy
+     * expected result:
+     *   the first invocation occurs on a cluster nodes, either node1 or node2
+     *   the second invocation occurs on the remaining cluster node, node2
+     */
+    @Test
+    public void testClusteredSLSBInvocationWithFailedNode() {
+        logger.info("=== Testing SLSB invocation with failed node ===");
+
+        Affinity expectedStrongAffinity = new ClusterAffinity("ejb");
+
+        // create a proxy for SLSB
+        final StatelessEJBLocator<Echo> statelessEJBLocator = StatelessEJBLocator.create(Echo.class, STATELESS_IDENTIFIER, expectedStrongAffinity);
+        Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+        Assert.assertNotNull("Received a null proxy", proxy);
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...");
+        final String message = "hello!";
+        Result<String> echoResult = proxy.echo(message);
+        logger.info("SLSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(SERVER1_NAME) || echoResult.getNode().equals(SERVER2_NAME));
+
+        undeployStateless(0);
+
+        // invoke on the proxy
+        logger.info("Invoking on proxy...");
+        echoResult = proxy.echo(message);
+        logger.info("SLSB invocation had target " + echoResult.getNode());
+
+        // check the message contents and the target
+        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+        Assert.assertTrue("Got an unexpected node for invocation target", echoResult.getNode().equals(SERVER2_NAME));
+
+        deployStateless(0);
     }
 
     /**
@@ -200,32 +435,17 @@ public class ClusteredInvocationTestCase {
      */
     @After
     public void afterTest() {
-        servers[0].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        logger.info("Unregistered module from " + serverNames[0]);
 
-        servers[1].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        logger.info("Unregistered module from " + serverNames[1]);
+        // wipe cluster
+        removeCluster(0, CLUSTER_NAME);
+        removeCluster(1, CLUSTER_NAME);
 
-        servers[0].removeCluster(CLUSTER_NAME);
-        servers[1].removeCluster(CLUSTER_NAME);
-
-        if (serversStarted[0]) {
-            try {
-                this.servers[0].stop();
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            }
+        // undeploy servers
+        for (int i = 0; i < 3; i++) {
+            undeployStateful(i);
+            undeployStateless(i);
+            stopServer(i);
         }
-        logger.info("Stopped server " + serverNames[0]);
-
-        if (serversStarted[1]) {
-            try {
-                this.servers[1].stop();
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            }
-        }
-        logger.info("Stopped server " + serverNames[1]);
     }
 
     /**
@@ -234,5 +454,4 @@ public class ClusteredInvocationTestCase {
     @AfterClass
     public static void afterClass() {
     }
-
 }

--- a/src/test/java/org/jboss/ejb/client/test/ManualTestRunner.java
+++ b/src/test/java/org/jboss/ejb/client/test/ManualTestRunner.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.ejb.client.test;
 
 import java.lang.reflect.Field;

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -17,10 +17,8 @@
  */
 package org.jboss.ejb.client.test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,15 +34,16 @@ import com.arjuna.ats.jta.common.jtaPropertyManager;
 import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.Echo;
 import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.ejb.client.test.common.StatefulEchoBean;
+import org.jboss.ejb.client.test.common.StatelessEchoBean;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.naming.client.WildFlyRootContext;
 import org.wildfly.naming.client.util.FastHashtable;
@@ -61,24 +60,10 @@ import org.wildfly.transaction.client.provider.jboss.JBossLocalTransactionProvid
  * @author Jason T. Greene
  * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
-public class TransactionTestCase {
+public class TransactionTestCase extends AbstractEJBClientTestCase {
     private static final Logger logger = Logger.getLogger(TransactionTestCase.class);
     private static ContextTransactionManager txManager;
     private static ContextTransactionSynchronizationRegistry txSyncRegistry;
-
-    private DummyServer server1, server2, server3, server4;
-    private boolean serverStarted = false;
-
-    // module
-    private static final String APP_NAME = "my-foo-app";
-    private static final String OTHER_APP = "my-other-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    private static final String SERVER1_NAME = "server1";
-    private static final String SERVER2_NAME = "server2";
-    private static final String SERVER3_NAME = "server3";
-    private static final String SERVER4_NAME = "server4";
 
     /**
      * Do any general setup here
@@ -107,24 +92,25 @@ public class TransactionTestCase {
     @Before
     public void beforeTest() throws Exception {
         // start a server
-        server1 = new DummyServer("localhost", 6999, SERVER1_NAME, true);
-        server2 = new DummyServer("localhost", 7999, SERVER2_NAME, true);
-        server3 = new DummyServer("localhost", 8999, SERVER3_NAME, true);
-        server4 = new DummyServer("localhost", 9999, SERVER4_NAME, true);
-        server1.start();
-        server2.start();
-        server3.start();
-        server4.start();
-        serverStarted = true;
-        logger.info("Started servers ...");
+        for (int i = 0; i < 4; i++) {
+            startServer(i, 6999 + (i*100), true);
+        }
 
-        server1.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER1_NAME));
-        server3.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER3_NAME));
-        server4.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER4_NAME));
+        deployStateless(0);
+        deployStateful(0);
+        // don't deploy on server 2 (index 1)
+        deployStateless(2);
+        deployStateful(2);
+        deployStateless(3);
+        deployStateful(3);
 
-        server2.register(OTHER_APP, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER2_NAME));
-        server3.register(OTHER_APP, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER3_NAME));
-        server4.register(OTHER_APP, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(SERVER4_NAME));
+        // don't deploy on server 1 (index 0)
+        deployOtherStateful(1);
+        deployOtherStateless(1);
+        deployOtherStateful(2);
+        deployOtherStateless(2);
+        deployOtherStateful(3);
+        deployOtherStateless(3);
     }
 
     @Test
@@ -152,10 +138,10 @@ public class TransactionTestCase {
         verifyNonTxBehavior(false, false);
     }
 
-    @Test
+   @Test
     public void testStatefulNonPropagatingInvocation() throws Exception {
         // Session open is sticky, resulting in a weak affinity and therefore
-        // sticykness even with non-propogating method calls.
+        // stickiness even with non-propagating method calls.
         verifyNonTxBehavior(true, true);
     }
 
@@ -173,7 +159,7 @@ public class TransactionTestCase {
         FastHashtable<String, Object> props = new FastHashtable<>();
 
         // Include all servers, so that retries are also tested
-        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7999, remote://localhost:8999, remote://localhost:9999");
+        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7099, remote://localhost:7199, remote://localhost:7299");
         props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
         WildFlyRootContext context = new WildFlyRootContext(props);
 
@@ -185,10 +171,12 @@ public class TransactionTestCase {
             HashMap<String, Integer> replies = new HashMap<>();
             String id = null;
             for (int i = 0; i < 20; i++) {
+                // get the correct bean name and interface depending on case
+                String beanInterface = Echo.class.getName();
+                String beanName = stateful ? StatefulEchoBean.class.getSimpleName() : StatelessEchoBean.class.getSimpleName();
 
-                Echo echo = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + EchoBean.class.getSimpleName() + "!"
-                        + Echo.class.getName() + (stateful ? "?stateful" : ""));
-                id = echo.whoAreYou();
+                Echo echo = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + beanName + "!" + beanInterface + (stateful ? "?stateful" : ""));
+                id = echo.echo("someMsg").getNode();
                 Integer existing = replies.get(id);
                 replies.put(id, existing == null ? 1 : existing + 1);
             }
@@ -202,13 +190,14 @@ public class TransactionTestCase {
         }
 
         // After 20 tries, we should have hit ever server but server2, which is missing the bean
-        Assert.assertEquals(Stream.of("server1", "server3", "server4").collect(Collectors.toSet()), ids);
+        Assert.assertEquals(Stream.of("node1", "node3", "node4").collect(Collectors.toSet()), ids);
     }
+
     private void verifyNonTxBehavior(boolean stateful, boolean sticky) throws Exception {
         FastHashtable<String, Object> props = new FastHashtable<>();
 
         // Include all servers, so that retries are also tested
-        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7999, remote://localhost:8999, remote://localhost:9999");
+        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7099, remote://localhost:7199, remote://localhost:7299");
         props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
         WildFlyRootContext context = new WildFlyRootContext(props);
 
@@ -219,10 +208,13 @@ public class TransactionTestCase {
             HashMap<String, Integer> replies = new HashMap<>();
             String id = null;
             for (int i = 0; i < 30; i++) {
+                // get the correct bean name and interface depending on case
+                String beanInterface = Echo.class.getName();
+                String beanName = stateful ? StatefulEchoBean.class.getSimpleName() : StatelessEchoBean.class.getSimpleName();
 
-                Echo echo = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + EchoBean.class.getSimpleName() + "!"
-                        + Echo.class.getName() + (stateful ? "?stateful" : ""));
-                id = echo.whoAreYouNonTX();
+                Echo echo = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + beanName + "!" + beanInterface + (stateful ? "?stateful" : ""));
+                // invoke the non-transactional version of echo
+                id = echo.echoNonTx("someMsg").getNode();
                 Integer existing = replies.get(id);
                 replies.put(id, existing == null ? 1 : existing + 1);
             }
@@ -237,19 +229,19 @@ public class TransactionTestCase {
         }
 
         // After 20 tries, we should have hit ever server but server2, which is missing the bean
-        Assert.assertEquals(Stream.of("server1", "server3", "server4").collect(Collectors.toSet()), ids);
+        Assert.assertEquals(Stream.of("node1", "node3", "node4").collect(Collectors.toSet()), ids);
     }
 
 
     @Test
     public void testTransactionPreference() throws Exception {
         FastHashtable<String, Object> props = new FastHashtable<>();
-        props.put("java.naming.provider.url", "remote://localhost:8999");
+        props.put("java.naming.provider.url", "remote://localhost:7199");
         props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
         WildFlyRootContext context2 = new WildFlyRootContext(props);
 
         props = new FastHashtable<>();
-        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7999, remote://localhost:8999, remote://localhost:9999");
+        props.put("java.naming.provider.url", "remote://localhost:6999, remote://localhost:7099, remote://localhost:7199, remote://localhost:7299");
         props.put("java.naming.factory.initial", WildFlyInitialContextFactory.class.getName());
         WildFlyRootContext context1 = new WildFlyRootContext(props);
 
@@ -261,8 +253,8 @@ public class TransactionTestCase {
             String id1 = null;
             for (int i = 0; i < 20; i++) {
 
-                Echo echo = (Echo) context1.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + EchoBean.class.getSimpleName() + "!" + Echo.class.getName());
-                id1 = echo.whoAreYou();
+                Echo echo = (Echo) context1.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + StatefulEchoBean.class.getSimpleName() + "!" + Echo.class.getName());
+                id1 = echo.echo("someMsg").getNode();
                 Integer existing = replies.get(id1);
                 replies.put(id1, existing == null ? 1 : existing + 1);
             }
@@ -276,8 +268,8 @@ public class TransactionTestCase {
             String id2 = null;
             for (int i = 0; i < 20; i++) {
 
-                Echo echo = (Echo) context1.lookup("ejb:" + OTHER_APP + "/" + MODULE_NAME + "/" + EchoBean.class.getSimpleName() + "!" + Echo.class.getName());
-                id2 = echo.whoAreYou();
+                Echo echo = (Echo) context1.lookup("ejb:" + OTHER_APP + "/" + MODULE_NAME + "/" + StatefulEchoBean.class.getSimpleName() + "!" + Echo.class.getName());
+                id2 = echo.echo("someMsg").getNode();
                 Integer existing = replies.get(id1);
                 replies.put(id1, existing == null ? 1 : existing + 1);
             }
@@ -287,20 +279,19 @@ public class TransactionTestCase {
             Assert.assertEquals(20, replies.values().iterator().next().intValue());
 
             System.out.println(id1 + ":" + id2);
-            if (id1.equals("server1")) {
-                Assert.assertTrue(Stream.of("server2", "server3", "server4").collect(Collectors.toSet()).contains(id2));
+            if (id1.equals("node1")) {
+                Assert.assertTrue(Stream.of("node2", "node3", "node4").collect(Collectors.toSet()).contains(id2));
             } else {
                 Assert.assertEquals(id1, id2);
             }
-
 
             id2s.add(id2);
             txManager.commit();
         }
 
         // After 80 tries, we should have hit every server for each app
-        Assert.assertEquals(Stream.of("server1", "server3", "server4").collect(Collectors.toSet()), id1s);
-        Assert.assertEquals(Stream.of("server2", "server3", "server4").collect(Collectors.toSet()), id2s);
+        Assert.assertEquals(Stream.of("node1", "node3", "node4").collect(Collectors.toSet()), id1s);
+        Assert.assertEquals(Stream.of("node2", "node3", "node4").collect(Collectors.toSet()), id2s);
     }
 
     /**
@@ -308,27 +299,24 @@ public class TransactionTestCase {
      */
     @After
     public void afterTest() {
-        server1.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server2.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server3.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server4.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server1.unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server2.unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server3.unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        server4.unregister(OTHER_APP, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        logger.info("Unregistered module ...");
 
-        if (serverStarted) {
-            try {
-                this.server1.stop();
-                this.server2.stop();
-                this.server3.stop();
-                this.server4.stop();
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            }
+        undeployStateless(0);
+        undeployStateful(0);
+        undeployStateless(2);
+        undeployStateful(2);
+        undeployStateless(3);
+        undeployStateful(3);
+
+        undeployOtherStateful(1);
+        undeployOtherStateless(1);
+        undeployOtherStateful(2);
+        undeployOtherStateless(2);
+        undeployOtherStateful(3);
+        undeployOtherStateless(3);
+
+        for (int i = 0; i < 4; i++) {
+            stopServer(i);
         }
-        logger.info("Stopped server ...");
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyAssociationImpl.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyAssociationImpl.java
@@ -17,10 +17,13 @@
  */
 package org.jboss.ejb.client.test.common;
 
+import org.jboss.ejb.client.Affinity;
+import org.jboss.ejb.client.ClusterAffinity;
 import org.jboss.ejb.client.EJBIdentifier;
 import org.jboss.ejb.client.EJBLocator;
 import org.jboss.ejb.client.EJBMethodLocator;
 import org.jboss.ejb.client.EJBModuleIdentifier;
+import org.jboss.ejb.client.NodeAffinity;
 import org.jboss.ejb.client.UUIDSessionID;
 import org.jboss.ejb.server.Association;
 import org.jboss.ejb.server.CancelHandle;
@@ -31,14 +34,15 @@ import org.jboss.ejb.server.ModuleAvailabilityListener;
 import org.jboss.ejb.server.Request;
 import org.jboss.ejb.server.SessionOpenRequest;
 import org.jboss.logging.Logger;
-import org.wildfly.common.annotation.NotNull;
 
 import org.jboss.ejb.client.test.common.DummyServer.EJBDeploymentRepository;
 import org.jboss.ejb.client.test.common.DummyServer.EJBDeploymentRepositoryListener;
 import org.jboss.ejb.client.test.common.DummyServer.EJBClusterRegistry;
 import org.jboss.ejb.client.test.common.DummyServer.EJBClusterRegistryListener;
+import org.wildfly.common.annotation.NotNull;
 
 import javax.ejb.EJBException;
+import javax.ejb.Stateful;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -57,10 +61,12 @@ public class DummyAssociationImpl implements Association {
 
     private static final Logger logger = Logger.getLogger(DummyAssociationImpl.class);
 
+    DummyServer server;
     EJBDeploymentRepository deploymentRepository ;
     EJBClusterRegistry clusterRegistry;
 
-    public DummyAssociationImpl(EJBDeploymentRepository repository, EJBClusterRegistry clusterRegistry) {
+    public DummyAssociationImpl(DummyServer server, EJBDeploymentRepository repository, EJBClusterRegistry clusterRegistry) {
+        this.server = server;
         this.deploymentRepository = repository;
         this.clusterRegistry = clusterRegistry;
     }
@@ -80,11 +86,16 @@ public class DummyAssociationImpl implements Association {
 
         // search the repository for the bean
         Object bean = deploymentRepository.findEJB(module, beanName);
-
         if (bean == null) {
+            deploymentRepository.dumpRegistry();
+
             invocationRequest.writeNoSuchEJB();;
             return CancelHandle.NULL;
         }
+
+        // check for stateful bean
+        boolean isStateful = isStateful(bean);
+        logger.info("Server (" + getHost() + ") received invocation request for " + (isStateful ? "stateful" : "stateless" ) + " bean " + beanName) ;
 
         // now invoke the bean, get the result, return the result
         // NOTE: we don't model ComponentViews of the bean  as is done in Wildfly; we just look for the invoked methods on the bean itself
@@ -115,13 +126,14 @@ public class DummyAssociationImpl implements Association {
 
         if (oneWay) {
             // send immediate response
+            updateInvocationAffinities(invocationRequest, attachments, ejbLocator, bean, isStateful);
             requestContent.writeInvocationResult(null);
         }
 
-        // this is a simpler cancellaction flag than required (see CancellationFlag)
+        // this is a simpler cancellation flag than required (see CancellationFlag)
         final AtomicBoolean cancelled = new AtomicBoolean();
         Runnable runnable = () -> {
-            // for handling cancellationof the invocation
+            // for handling cancellation of the invocation
             if (cancelled.get()) {
                 if (!oneWay) invocationRequest.writeCancelResponse();
                 return;
@@ -147,8 +159,8 @@ public class DummyAssociationImpl implements Association {
 
             // invocation was successful - prepare the result
             if (! oneWay) {
-                // attach any weak affinity if available
-                // TODO
+                // update affinities before returning
+                updateInvocationAffinities(invocationRequest, attachments, ejbLocator, bean, isStateful);
                 requestContent.writeInvocationResult(retVal);
             }
         };
@@ -202,14 +214,19 @@ public class DummyAssociationImpl implements Association {
         final EJBModuleIdentifier module = ejbIdentifier.getModuleIdentifier();
         final String beanName = ejbIdentifier.getBeanName();
 
+        logger.info("Server (" + getHost() + ") received session open request for bean named " + beanName + ", looking for deployment...");
+
         // search the repository for the bean
         Object bean = deploymentRepository.findEJB(module, beanName);
+
 
         if (bean == null) {
             sessionOpenRequest.writeNoSuchEJB();;
             return CancelHandle.NULL;
         }
 
+        boolean isStateful = isStateful(bean);
+        logger.info("Server (" + getHost() + ") received session open request for " + (isStateful ? "stateful" : "stateless" ) + " bean " + beanName ) ;
 
         // now invoke the bean, get the result, return the result
         final AtomicBoolean cancelled = new AtomicBoolean();
@@ -221,11 +238,99 @@ public class DummyAssociationImpl implements Association {
             final UUID uuid = UUID.randomUUID();
             UUIDSessionID sessionID = new UUIDSessionID(uuid);
 
+            // update affinities
+            updateSessionAffinities(sessionOpenRequest, bean);
             sessionOpenRequest.convertToStateful(sessionID);
         };
         execute(sessionOpenRequest, runnable, false);
         return ignored -> cancelled.set(true);
     }
+
+    /**
+     * Determine the affinities for this session based on the server state
+     *
+     * Rules:
+     *   strong affinity: if SFSB or SLSB bean is on a clustered node, set strong = cluster
+     *   weak affinity: if SFSB is on a clustered node, set weak-= Node
+     *
+     * @param sessionOpenRequest
+     * @param bean
+     */
+    private void updateSessionAffinities(SessionOpenRequest sessionOpenRequest, Object bean) {
+        Affinity weakAffinity = null;
+        Affinity strongAffinity = null;
+
+        // NOTE: if we arrive here, we know the bean is stateful
+
+        // if the session bean is created on a clustered node, tie it to the cluster
+        if (isClusterMember(bean, "ejb")) {
+            strongAffinity = new ClusterAffinity("ejb");
+            weakAffinity = new NodeAffinity(getHost());
+        }
+
+        // set the affinities in the reply
+        if (strongAffinity != null) {
+            // set the strong affinity here
+            sessionOpenRequest.updateStrongAffinity(strongAffinity);
+        }
+        if (weakAffinity != null && !weakAffinity.equals(Affinity.NONE)) {
+            // set the weak affinity here
+            sessionOpenRequest.updateWeakAffinity(weakAffinity);
+        }
+
+        logger.info("Server (" + getHost() + ") updated session affinities for bean " + bean.getClass().getName() + ": (strong, weak) = (" + strongAffinity + "," + weakAffinity + ")") ;
+    }
+
+    /**
+     * Determine the affinities for this invocation based on server state.
+     *
+     * Rules:
+     *   strong affinity: if SFSB or SLSB bean is on a clustered node, no change
+     *   weak affinity: if SFSB is on a clustered node, set weak-= Node
+     *
+     * @param invocationRequest
+     * @param attachments
+     * @param ejbLocator
+     */
+    private void updateInvocationAffinities(InvocationRequest invocationRequest, Map<String, Object> attachments, EJBLocator<?> ejbLocator, Object bean, boolean isStateful) {
+        Affinity legacyAffinity = null;
+        Affinity weakAffinity = null;
+        Affinity strongAffinity = null;
+        Affinity clusterAffinity = null;
+
+        // NOTE: if we arrive here, the bean could be stateful or stateless
+
+        // calculate the affinities
+        if (isStateful) {
+            // for SFSB touching a clustered node, set both strong and weak affinity
+            if (isClusterMember(bean, "ejb")) {
+                strongAffinity = new ClusterAffinity("ejb");
+                weakAffinity = new NodeAffinity(getHost());
+
+            }
+        } else {
+            // for SLSB touching a clustered node, just set strong affinity to cluster
+            if (isClusterMember(bean, "ejb")) {
+                strongAffinity = new ClusterAffinity("ejb");
+            }
+        }
+
+        // set the affinities in the reply
+        if (strongAffinity != null) {
+            invocationRequest.updateStrongAffinity(strongAffinity);
+        }
+        if (weakAffinity != null && !weakAffinity.equals(Affinity.NONE)) {
+            invocationRequest.updateWeakAffinity(weakAffinity);
+        }
+
+        // TODO: handle protocol versions less than 3
+        if (legacyAffinity != null && !legacyAffinity.equals(Affinity.NONE)) {
+            attachments.put(Affinity.WEAK_AFFINITY_CONTEXT_KEY, legacyAffinity);
+        }
+
+        logger.info("Server (" + getHost() + ") updated invocation affinities for bean " + bean.getClass().getName() + ": (strong, weak) = (" + strongAffinity + "," + weakAffinity + ")") ;
+    }
+
 
     /*
      * We can decidie to run tasks in-line or on an executor
@@ -317,5 +422,28 @@ public class DummyAssociationImpl implements Association {
         // register the listener and return a handle that can be used to later remove it
         this.deploymentRepository.addListener(listener);
         return () -> deploymentRepository.removeListener(listener);
+    }
+
+    /**
+     * Method to check of a bean is marked at @Stateful
+     * @param bean
+     * @return
+     */
+    boolean isStateful(Object bean) {
+        return bean.getClass().isAnnotationPresent(Stateful.class);
+    }
+
+    /**
+     * Method to check if a bean is deployed on a node in a given cluster
+     * @param bean
+     * @param clusterName
+     * @return
+     */
+    boolean isClusterMember(Object bean, String clusterName) {
+        return clusterRegistry.isClusterMember(clusterName);
+    }
+
+    String getHost() {
+        return server.getEndpointName();
     }
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
@@ -92,6 +92,18 @@ public class DummyServer {
         this.startTxServer = startTxService;
     }
 
+    public int getPort() {
+        return port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getEndpointName() {
+        return endpointName;
+    }
+
     public void start() throws Exception {
         logger.info("Starting " + this);
 
@@ -147,7 +159,7 @@ public class DummyServer {
 
         // set up an association to handle invocations, session creations and module/toopology listensrs
         // the association makes use of a module deployment repository as well a sa  cluster registry
-        Association dummyAssociation = new DummyAssociationImpl(deploymentRepository, clusterRegistry);
+        Association dummyAssociation = new DummyAssociationImpl(this, deploymentRepository, clusterRegistry);
 
         // set up a remoting transaction service
         RemotingTransactionService.Builder txnServiceBuilder = RemotingTransactionService.builder();
@@ -245,12 +257,12 @@ public class DummyServer {
 
         Object findEJB(EJBModuleIdentifier module, String beanName) {
             final Map<String, Object> ejbs = this.registeredEJBs.getOrDefault(module, Collections.emptyMap());
-            final Object beanInstance = ejbs.get(beanName);
-            if (beanInstance == null) {
+            final Object instance = ejbs.get(beanName);
+            if (instance == null) {
                 // any exception will be handled by the caller on seeing null
                 return null;
             }
-            return beanInstance ;
+            return instance ;
         }
 
         void addListener(EJBDeploymentRepositoryListener listener) {
@@ -265,6 +277,13 @@ public class DummyServer {
 
         void removeListener(EJBDeploymentRepositoryListener listener) {
             listeners.remove(listener);
+        }
+
+        void dumpRegistry() {
+            System.out.println("\n");
+            System.out.println("Dumping registered EJBs");
+            System.out.println(registeredEJBs.toString());
+            System.out.println("\n");
         }
     }
 
@@ -287,6 +306,10 @@ public class DummyServer {
         List<EJBClusterRegistryListener> listeners = new ArrayList<EJBClusterRegistryListener>();
 
         EJBClusterRegistry() {
+        }
+
+        boolean isClusterMember(String clusterName) {
+            return joinedClusters.keySet().contains(clusterName);
         }
 
         void addCluster(ClusterInfo cluster) {

--- a/src/test/java/org/jboss/ejb/client/test/common/Echo.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/Echo.java
@@ -24,11 +24,8 @@ import org.jboss.ejb.client.annotation.ClientTransactionPolicy;
  * User: jpai
  */
 public interface Echo {
-
-    String echo(String msg);
-
-    String whoAreYou();
+    Result<String> echo(String msg);
 
     @ClientTransaction(ClientTransactionPolicy.NOT_SUPPORTED)
-    String whoAreYouNonTX();
+    Result<String> echoNonTx(String msg);
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/EchoBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/EchoBean.java
@@ -27,27 +27,26 @@ import org.jboss.logging.Logger;
 public class EchoBean implements Echo {
 
     private static final Logger logger = Logger.getLogger(EchoBean.class);
-    private final String whoami;
+    private final String node;
 
     public EchoBean() {
-        this("noidea");
+        this("unknown");
     }
 
-    public EchoBean(String whoami) {
-        this.whoami = whoami;
+    public EchoBean(String node) {
+        this.node = node;
     }
 
     @Override
-    public String echo(String msg) {
+    public Result<String> echo(String msg) {
         logger.info(this.getClass().getSimpleName() + " echoing message " + msg);
-        return msg;
+        return new Result<String>(msg, node);
     }
 
-    public String whoAreYou() {
-        return whoami;
+    @Override
+    public Result<String> echoNonTx(String msg) {
+        logger.info(this.getClass().getSimpleName() + " echoing message (NonTx) " + msg);
+        return new Result<String>(msg, node);
     }
 
-    public String whoAreYouNonTX() {
-        return whoAreYou();
-    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/FooBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/FooBean.java
@@ -19,26 +19,26 @@ package org.jboss.ejb.client.test.common;
 
 import org.jboss.logging.Logger;
 
+import javax.ejb.Stateful;
+
 /**
  * User: jpai
  */
+@Stateful
 public class FooBean implements Echo {
 
     private static final Logger logger = Logger.getLogger(FooBean.class);
 
     @Override
-    public String echo(String msg) {
+    public Result<String> echo(String msg) {
         logger.info(this.getClass().getSimpleName() + " echoing message " + msg);
-        return msg;
+        return new Result<String>(msg, "no idea!");
     }
 
     @Override
-    public String whoAreYou() {
-        return "no idea!";
+    public Result<String> echoNonTx(String msg) {
+        logger.info(this.getClass().getSimpleName() + " echoing message " + msg);
+        return new Result<String>(msg, "no idea!");
     }
 
-    @Override
-    public String whoAreYouNonTX() {
-        return "no idea!";
-    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/Result.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/Result.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2017 Red Hat, Inc., and individual contributors
+ * Copyright 2019 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,29 @@
  */
 package org.jboss.ejb.client.test.common;
 
-import javax.ejb.Stateful;
+import java.io.Serializable;
 
 /**
- * User: jpai
+ * /**
+ * A wrapper for a return value that includes the node on which the result was generated.
+ * @author Paul Ferraro
  */
-public interface Foo {
 
-    Result<String> echo(String msg);
+public class Result<T> implements Serializable {
+    private static final long servialVersionUID = 12345L ;
+    private final T value;
+    private final String node;
+
+    public Result(T value, String node) {
+        this.value = value;
+        this.node = node;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public String getNode() {
+        return node;
+    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/StatefulEchoBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/StatefulEchoBean.java
@@ -20,9 +20,13 @@ package org.jboss.ejb.client.test.common;
 import javax.ejb.Stateful;
 
 /**
+ * An instance of Echo marked explicitly as stateful.
+ *
  * User: jpai
  */
-public interface Foo {
-
-    Result<String> echo(String msg);
+@Stateful
+public class StatefulEchoBean extends EchoBean {
+    public StatefulEchoBean(String node) {
+        super(node);
+    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/common/StatelessEchoBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/StatelessEchoBean.java
@@ -17,12 +17,16 @@
  */
 package org.jboss.ejb.client.test.common;
 
-import javax.ejb.Stateful;
+import javax.ejb.Stateless;
 
 /**
+ * An instance of Echo marked explicitly as stateless.
+ *
  * User: jpai
  */
-public interface Foo {
-
-    Result<String> echo(String msg);
+@Stateless
+public class StatelessEchoBean extends EchoBean {
+    public StatelessEchoBean(String node) {
+        super(node);
+    }
 }

--- a/src/test/java/org/jboss/ejb/protocol/remote/NetworkUtilTestCase.java
+++ b/src/test/java/org/jboss/ejb/protocol/remote/NetworkUtilTestCase.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.ejb.protocol.remote;
 
 import static org.junit.Assert.*;

--- a/src/test/resources/clustered-jboss-ejb-client.properties
+++ b/src/test/resources/clustered-jboss-ejb-client.properties
@@ -18,7 +18,7 @@
 
 remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 
-remote.connections=one,two
+remote.connections=one,two,three
 
 # connection to a node at protocol://host:port
 remote.connection.one.host=localhost
@@ -37,6 +37,15 @@ remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=f
 remote.connection.two.username=test
 remote.connection.two.password=test
 remote.connection.two.realm=default
+
+# connection to a node at protocol://host:port
+remote.connection.three.host=localhost
+remote.connection.three.port=7199
+remote.connection.three.protocol=remote
+remote.connection.three.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.three.username=test
+remote.connection.three.password=test
+remote.connection.three.realm=default
 
 # the nodes are clustered in a cluster called ejb and have names node1, node2
 remote.clusters=ejb

--- a/src/test/resources/deployment-node-selector-jboss-ejb-client.properties
+++ b/src/test/resources/deployment-node-selector-jboss-ejb-client.properties
@@ -33,7 +33,7 @@ remote.connection.one.realm=default
 
 # connection to a node at protocol://host:port
 remote.connection.two.host=localhost
-remote.connection.two.port=7999
+remote.connection.two.port=7099
 remote.connection.two.protocol=remote
 remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
 remote.connection.two.username=test

--- a/src/test/resources/jboss-ejb-client.properties
+++ b/src/test/resources/jboss-ejb-client.properties
@@ -18,7 +18,7 @@
 
 remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 
-remote.connections=one
+remote.connections=one,two
 
 # connection to a node at protocol://host:port
 remote.connection.one.host=localhost
@@ -27,3 +27,11 @@ remote.connection.one.protocol=remote
 remote.connection.one.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
 remote.connection.one.username=test
 remote.connection.one.password=test
+
+# connection to a node at protocol://host:port
+remote.connection.two.host=localhost
+remote.connection.two.port=7099
+remote.connection.two.protocol=remote
+remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.two.username=test
+remote.connection.two.password=test


### PR DESCRIPTION
This PR aims to add features to the EJB client testsuite in order to better validate affinity processing.
For details, see: https://issues.jboss.org/browse/EJBCLIENT-263

(NOTE: I had to recreate the pull request in GitHub due to changing the branch name). For reference, the old pull request was: https://github.com/wildfly/jboss-ejb-client/pull/310)