### PR TITLE
[EJBCLIENT-325] Clean up crashed/shutdown singleton cluster nodes from DNR

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -318,11 +318,14 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             if (weakAffinity instanceof NodeAffinity) {
                 filterSpec = FilterSpec.all(
                     FilterSpec.equal(FILTER_ATTR_CLUSTER, ((ClusterAffinity) affinity).getClusterName()),
-                    FilterSpec.equal(FILTER_ATTR_NODE, ((NodeAffinity) weakAffinity).getNodeName())
+                    FilterSpec.equal(FILTER_ATTR_NODE, ((NodeAffinity) weakAffinity).getNodeName()),
+                    // require that the module be deployed on the chosen node
+                    getFilterSpec(locator.getIdentifier().getModuleIdentifier())
                 );
                 fallbackFilterSpec = FilterSpec.all(
                     FilterSpec.equal(FILTER_ATTR_CLUSTER, ((ClusterAffinity) affinity).getClusterName()),
-                    FilterSpec.hasAttribute(FILTER_ATTR_NODE)
+                    FilterSpec.hasAttribute(FILTER_ATTR_NODE),
+                    getFilterSpec(locator.getIdentifier().getModuleIdentifier())
                 );
                 return doFirstMatchDiscovery(context, filterSpec, fallbackFilterSpec);
             } else if (weakAffinity instanceof URIAffinity || weakAffinity == Affinity.LOCAL) {
@@ -333,13 +336,16 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
             } else {
                 // regular cluster discovery
                 filterSpec = FilterSpec.all(
-                    FilterSpec.equal(FILTER_ATTR_CLUSTER, ((ClusterAffinity) affinity).getClusterName())
+                    FilterSpec.equal(FILTER_ATTR_CLUSTER, ((ClusterAffinity) affinity).getClusterName()),
+                    // require that the module be deployed on the chosen node
+                    getFilterSpec(locator.getIdentifier().getModuleIdentifier())
                 );
                 return doClusterDiscovery(context, filterSpec);
             }
         } else {
             // no affinity in particular
             assert affinity == Affinity.NONE;
+            // aseert the module to be present
             filterSpec = getFilterSpec(locator.getIdentifier().getModuleIdentifier());
             return doAnyDiscovery(context, filterSpec, locator);
         }

--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
@@ -208,8 +208,9 @@ class EJBClientChannel {
                         final String distinctName = message.readUTF();
                         final EJBModuleIdentifier moduleIdentifier = new EJBModuleIdentifier(appName, moduleName, distinctName);
                         moduleList[i] = moduleIdentifier;
+
                         if (Logs.INVOCATION.isDebugEnabled()) {
-                            Logs.INVOCATION.debugf("Received MODULE_AVAILABLE(%x) message from %s for module %s", msg, remoteEndpoint, moduleIdentifier);
+                            Logs.INVOCATION.debugf("Received MODULE_AVAILABLE(%x) message from node %s for module %s", msg, remoteEndpoint, moduleIdentifier);
                         }
                     }
                     nodeInformation.addModules(this, moduleList);
@@ -226,8 +227,9 @@ class EJBClientChannel {
                         final String distinctName = message.readUTF();
                         final EJBModuleIdentifier moduleIdentifier = new EJBModuleIdentifier(appName, moduleName, distinctName);
                         set.add(moduleIdentifier);
+
                         if (Logs.INVOCATION.isDebugEnabled()) {
-                            Logs.INVOCATION.debugf("Received MODULE_UNAVAILABLE(%x) message from %s for module %s", msg, remoteEndpoint, moduleIdentifier);
+                            Logs.INVOCATION.debugf("Received MODULE_UNAVAILABLE(%x) message from node %s for module %s", msg, remoteEndpoint, moduleIdentifier);
                         }
                     }
                     nodeInformation.removeModules(this, set);
@@ -243,8 +245,9 @@ class EJBClientChannel {
                             final String nodeName = message.readUTF();
                             discoveredNodeRegistry.addNode(clusterName, nodeName, channel.getConnection().getPeerURI());
                             final NodeInformation nodeInformation = discoveredNodeRegistry.getNodeInformation(nodeName);
+
                             if (Logs.INVOCATION.isDebugEnabled()) {
-                                Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY(%x) message from %s, registering cluster %s to node %s", msg, remoteEndpoint, clusterName, nodeName);
+                                Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY(%x) message from node %s, registering cluster %s to node %s", msg, remoteEndpoint, clusterName, nodeName);
                             }
 
                             // create and register the concrete ServiceURLs for each client mapping
@@ -274,9 +277,11 @@ class EJBClientChannel {
                     for (int i = 0; i < clusterCount; i ++) {
                         String clusterName = message.readUTF();
                         discoveredNodeRegistry.removeCluster(clusterName);
+
                         if (Logs.INVOCATION.isDebugEnabled()) {
-                            Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY_REMOVAL(%x) message from %s for cluster %s", msg, remoteEndpoint, clusterName);
+                            Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY_REMOVAL(%x) message from node %s for cluster %s", msg, remoteEndpoint, clusterName);
                         }
+
                         for (NodeInformation nodeInformation : discoveredNodeRegistry.getAllNodeInformation()) {
                             nodeInformation.removeCluster(clusterName);
                         }
@@ -293,8 +298,9 @@ class EJBClientChannel {
                             discoveredNodeRegistry.removeNode(clusterName, nodeName);
                             final NodeInformation nodeInformation = discoveredNodeRegistry.getNodeInformation(nodeName);
                             nodeInformation.removeCluster(clusterName);
+
                             if (Logs.INVOCATION.isDebugEnabled()) {
-                                Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY_NODE_REMOVAL(%x) message from %s for (cluster, node) = (%s, %s)", msg, remoteEndpoint, clusterName, nodeName);
+                                Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY_NODE_REMOVAL(%x) message from node %s for (cluster, node) = (%s, %s)", msg, remoteEndpoint, clusterName, nodeName);
                             }
                         }
                     }

--- a/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
@@ -25,6 +25,7 @@ import static org.jboss.ejb.client.EJBClientContext.FILTER_ATTR_NODE;
 import static org.jboss.ejb.client.EJBClientContext.getCurrent;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -221,7 +222,7 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
         }
         // special second pass - retry everything because all were marked failed
         if (discoveryConnections && ! ok) {
-            Logs.INVOCATION.tracef("EJB discovery provider: all connections marked failed, retrying ...");
+            Logs.INVOCATION.tracef("EJB discovery provider: all discovery-enabled configured connections marked failed, retrying configured connections ...");
             for (EJBClientConnection connection : configuredConnections) {
                 if (! connection.isForDiscovery()) {
                     continue;
@@ -311,6 +312,13 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
         }
     };
 
+    /**
+     * This method gets a ConnectionPeerIdentity object for a remote connection to a destination, similar to Endpoint.getConnectedIdentity().
+     * However, if we call it with a cluster name, indicating that we are connecting to a cluster, instead of looking up the AuthenticationContext
+     * for the cluster member destination, it instead uses the AuthenticationContext for the URI which first connected to the cluster.
+     * This is the cluster effective URI, in the sense that it is an effective URI (i.e. resolved) for a cluster - the same credentials will be used
+     * no matter which cluster member we connect to.
+     */
     IoFuture<ConnectionPeerIdentity> getConnectedIdentityUsingClusterEffective(Endpoint endpoint, URI destination, String abstractType, String abstractTypeAuthority, AuthenticationContext context, String clusterName) {
         Assert.checkNotNullParam("destination", destination);
         Assert.checkNotNullParam("context", context);
@@ -352,6 +360,9 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
         private final List<Runnable> cancellers = Collections.synchronizedList(new ArrayList<>());
         private final IoFuture.HandlingNotifier<ConnectionPeerIdentity, URI> outerNotifier;
         private final IoFuture.HandlingNotifier<EJBClientChannel, URI> innerNotifier;
+        // keep a record of URIs we try to connect to for each cluster
+        private final ConcurrentHashMap<String, Set<URI>> urisByCluster = new ConcurrentHashMap<>();
+        private final Set<URI> connectFailedURIs = new HashSet<>();
 
         DiscoveryAttempt(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult discoveryResult, final RemoteEJBReceiver ejbReceiver, final AuthenticationContext authenticationContext) {
             this.serviceType = serviceType;
@@ -369,6 +380,10 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
                 public void handleFailed(final IOException exception, final URI destination) {
                     DiscoveryAttempt.this.discoveryResult.reportProblem(exception);
                     failedDestinations.put(destination, System.nanoTime());
+                    if (exception instanceof ConnectException) {
+                        connectFailedURIs.add(destination);
+                        Logs.INVOCATION.tracef("DiscoveryAttempt: got ConnectException on node with destination = %s", destination);
+                    }
                     countDown();
                 }
 
@@ -403,6 +418,12 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
                 return;
             }
             outstandingCount.getAndIncrement();
+
+            // keep a record of this URI if it has an associated cluster (EJBCLIENT-325)
+            if (clusterEffective != null) {
+                urisByCluster.computeIfAbsent(clusterEffective, ignored -> Collections.newSetFromMap(new ConcurrentHashMap<>())).add(uri);
+            }
+
             final IoFuture<ConnectionPeerIdentity> future = doPrivileged((PrivilegedAction<IoFuture<ConnectionPeerIdentity>>) () -> getConnectedIdentityUsingClusterEffective(endpoint, uri, "ejb", "jboss", authenticationContext, clusterEffective));
             onCancel(future::cancel);
             future.addNotifier(outerNotifier, uri);
@@ -410,6 +431,23 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
 
         void countDown() {
             if (outstandingCount.decrementAndGet() == 0) {
+
+                // before calculating the search result, update DNR to remove crashed last members of clusters (EJBCLIENT-325)
+                for (String cluster : urisByCluster.keySet()) {
+                    Set<URI> uris = urisByCluster.get(cluster);
+                      if (uris != null && uris.size() == 1) {
+                        // get the URI and check if it represents a failed last cluster member
+                        URI uri = uris.iterator().next();
+                        if (connectFailedURIs.contains(uri)) {
+                            Logs.INVOCATION.tracef("DiscoveryAttempt: countDown() found a cluster %s with one failed destination, %s, removing cluster", cluster, uri);
+                            removeCluster(cluster);
+                            for (NodeInformation nodeInformation : getAllNodeInformation()) {
+                                nodeInformation.removeCluster(cluster);
+                            }
+                        }
+                    }
+                }
+
                 final DiscoveryResult result = this.discoveryResult;
                 final String node = filterSpec.accept(NODE_EXTRACTOR);
                 final EJBModuleIdentifier module = filterSpec.accept(MI_EXTRACTOR);

--- a/src/test/java/org/jboss/ejb/client/test/LastNodeToLeaveTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/LastNodeToLeaveTestCase.java
@@ -1,0 +1,386 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.ejb.client.test;
+
+import org.jboss.ejb.client.ClusterAffinity;
+import org.jboss.ejb.client.ClusterNodeSelector;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
+import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.Echo;
+import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.ejb.server.ClusterTopologyListener;
+import org.jboss.ejb.server.ClusterTopologyListener.ClusterInfo;
+import org.jboss.ejb.server.ClusterTopologyListener.NodeInfo;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ejb.NoSuchEJBException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Tests the ability of the the RemoteEJBDiscoveryProvider to detect the condition when a last node left in a cluster has crashed
+ * and to remove that cluster from the discovered node registry (DNR).
+ * The condition is as follows: if we get a ConnectException when trying to connect to a node X in cluster Y, and the DNR shows
+ * X as being the only member of Y, then remove cluster Y from the DNR.
+ *
+ * This test implements a validation criterion which ensures that the following illegal scenario does not occur:
+ * - start two cluster nodes A, B:              // membership = {A,B}
+ * - shutdown A                                 // membership = {B}
+ * - crash B                                    // membership = {B}
+ * - start A                                    // membership = {A,B}
+ * In this case, B is e member of the cluster (according to the DNR) but it has crashed.
+ *
+ *
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public class LastNodeToLeaveTestCase {
+
+    private static final Logger logger = Logger.getLogger(LastNodeToLeaveTestCase.class);
+    private static final String PROPERTIES_FILE = "last-node-to-leave-jboss-ejb-client.properties";
+
+    // servers
+    private static final String SERVER1_NAME = "node1";
+    private static final String SERVER2_NAME = "node2";
+    private static final int THREADS = 4;
+    private static final int INTERVAL_TIME_SECS = 3;
+    private static final int INVOCATION_DELAY_SECS = 1;
+
+    private DummyServer[] servers = new DummyServer[2];
+    private static String[] serverNames = {SERVER1_NAME, SERVER2_NAME};
+    private static boolean[] serversStarted = new boolean[2] ;
+
+    // module
+    private static final String APP_NAME = "my-foo-app";
+    private static final String MODULE_NAME = "my-bar-module";
+    private static final String DISTINCT_NAME = "";
+
+    // cluster
+    // note: node names and server names should match!
+    private static final String CLUSTER_NAME = "ejb";
+    private static final String NODE1_NAME = "node1";
+    private static final String NODE2_NAME = "node2";
+
+    private static final NodeInfo NODE1 = DummyServer.getNodeInfo(NODE1_NAME, "localhost",6999,"0.0.0.0",0);
+    private static final NodeInfo NODE2 = DummyServer.getNodeInfo(NODE2_NAME, "localhost",7099,"0.0.0.0",0);
+    private static final ClusterInfo CLUSTER = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
+    private static final ClusterInfo CLUSTER_NODE1 = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1);
+    private static final ClusterInfo CLUSTER_NODE2 = DummyServer.getClusterInfo(CLUSTER_NAME, NODE2);
+
+    private static final ClusterTopologyListener.ClusterRemovalInfo CLUSTER_REMOVE_NODE1 = DummyServer.getClusterRemovalInfo(CLUSTER_NAME, NODE1);
+    private static final ClusterTopologyListener.ClusterRemovalInfo CLUSTER_REMOVE_NODE2 = DummyServer.getClusterRemovalInfo(CLUSTER_NAME, NODE2);
+
+    private static ExecutorService executorService;
+    private volatile boolean runInvocations = true;
+
+    /**
+     * Do any general setup here
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // trigger the static init of the correct properties file - this also depends on running in forkMode=always
+        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
+        JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
+
+        executorService = Executors.newFixedThreadPool(THREADS);
+    }
+
+    /**
+     * Do any test specific setup here
+     */
+    @Before
+    public void beforeTest() throws Exception {
+
+        startServer(0, CLUSTER);
+        startServer(1, CLUSTER);
+    }
+
+    /*
+     * Returns a list of true/fase values describing current server availability.
+     */
+    public static List<Boolean> getServersStarted() {
+        List<Boolean> booleanList = new ArrayList<Boolean>();
+        for (int i = 0; i < serversStarted.length; i++) {
+            booleanList.add(new Boolean(serversStarted[i]));
+        }
+        return booleanList;
+    }
+
+    public static class SelectorResult {
+        String cluster;
+        List<String> connectedNodes;
+        List<String> availableNodes;
+        List<Boolean> serversAvailable;
+
+        public SelectorResult(String cluster, List<String> connectedNodes, List<String> availableNodes, List<Boolean> serversAvailable) {
+            this.cluster = cluster;
+            this.connectedNodes = connectedNodes;
+            this.availableNodes = availableNodes;
+            this.serversAvailable = serversAvailable;
+        }
+
+        /**
+         * This should assert that no non-available server nodes should be present in either connected nodes nor available nodes
+         *
+         * @return true of the assertion holds; false otherwise
+         */
+        public boolean checkResult() {
+            for (int i = 0; i < serverNames.length; i++) {
+                // check that no non-available server is in the available nodes list for this cluster
+                if (!serversAvailable.get(i) && availableNodes.contains(serverNames[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "SelectorResult{" + "cluster='" + cluster + '\'' + ", connectedNodes=" + connectedNodes + ", availableNodes=" + availableNodes + ", serversAvailable=" + serversAvailable + '}';
+        }
+    }
+
+    // results of the selector visits
+    public static ConcurrentHashMap<String, List<SelectorResult>> selectorResults = new ConcurrentHashMap<String, List<SelectorResult>>();
+
+    public static class TestSelector implements ClusterNodeSelector {
+
+        @Override
+        public String selectNode(String clusterName, String[] connectedNodes, String[] availableNodes) {
+            SelectorResult selectorResult = new SelectorResult(clusterName, Arrays.asList(connectedNodes), Arrays.asList(availableNodes), getServersStarted());
+            selectorResults.computeIfAbsent(Thread.currentThread().getName(), ignored -> new ArrayList<SelectorResult>()).add(selectorResult);
+
+            logger.infof("logging selector result: %s", selectorResult);
+            // now pick a random node
+            return RANDOM_CONNECTED.selectNode(clusterName, connectedNodes, availableNodes);
+        }
+    }
+
+
+    /**
+     * Test a basic invocation on clustered SLSB
+     */
+    @Test
+    public void testClusteredSLSBInvocation() throws Exception {
+        List<Future<?>> retList = new ArrayList<>();
+
+        for(int i = 0; i < THREADS; ++i) {
+            retList.add(executorService.submit((Callable<Object>) () -> {
+                // create a proxy
+                final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
+                final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+
+                EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
+                Assert.assertNotNull("Received a null proxy", proxy);
+                logger.info("Created proxy for Echo: " + proxy.toString());
+
+                while (runInvocations) {
+                    logger.info("Invoking on proxy...");
+                    // invoke on the proxy (use a ClusterAffinity for now)
+                    final String message = "hello!";
+                    // one second delay between invocations
+                    Thread.sleep(INVOCATION_DELAY_SECS * 1000);
+
+                    String echo = null;
+                    try {
+                        echo = proxy.echo(message);
+                    } catch(NoSuchEJBException e) {
+                        logger.info("Got NoSuchEJBException from node, skipping...");
+                        echo = message;
+                    }
+                    Assert.assertEquals("Got an unexpected echo", echo, message);
+                }
+                return "ok";
+            }));
+        }
+
+        // stop one of the two servers ( {node1, node2} -> {node2})
+        Thread.sleep(INTERVAL_TIME_SECS * 1000);
+        stopServer(0, CLUSTER_REMOVE_NODE1);
+        servers[1].removeClusterNodes(CLUSTER_REMOVE_NODE1);
+        Thread.sleep(INTERVAL_TIME_SECS * 1000);
+
+        // now crash the last server in the cluster  ( {node2} -> {})
+        crashServer(1);
+        Thread.sleep(INTERVAL_TIME_SECS * 1000);
+
+        // restart one of the two servers - we should not see server1 as being available  ( {} -> {node1})
+        startServer(0, CLUSTER_NODE1);
+
+        Thread.sleep(INTERVAL_TIME_SECS * 1000);
+
+        // stop the client
+        runInvocations = false;
+
+        // check the list of connected and available servers
+        for(Future<?> i : retList) {
+            try {
+                i.get();
+            } catch(Exception e) {
+                logger.infof("Got exception processing client thread future: exception = %s", e.toString());
+            }
+        }
+
+        // print and validate the results
+        for(Map.Entry<String, List<SelectorResult>> entry : selectorResults.entrySet()) {
+            String thread = entry.getKey();
+            List<SelectorResult> selectorResults = entry.getValue();
+            logger.infof("Test results for thread = %s:\n", thread);
+            for (SelectorResult selectorResult : selectorResults) {
+                logger.infof("Selector result: %s", selectorResult);
+                Assert.assertTrue(selectorResult.checkResult());
+            }
+        }
+    }
+
+    /**
+     * Starts a cluster node with the default cluster membership (i.e. {node1, node2})
+     * @param server the server number
+     * @throws Exception
+     */
+    private void startServer(int server) throws Exception {
+        servers[server] = new DummyServer("localhost", 6999 + (server * 100), serverNames[server]);
+        servers[server].start();
+        serversStarted[server] = true;
+        logger.info("Started server " + serverNames[server]);
+
+        servers[server].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
+        logger.info("Registered module on server " + servers[server]);
+
+        servers[server].addCluster(CLUSTER);
+        logger.info("Added node to cluster " + CLUSTER_NAME + ": server " + servers[server]);
+
+    }
+
+    /**
+     * Stops a server with the default cluster being removed (i.e. {node1, node2})
+     *
+     * @param server the server number
+     */
+    private void stopServer(int server) {
+        if (serversStarted[server]) {
+            try {
+                servers[server].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+                servers[server].removeCluster(CLUSTER_NAME);
+                logger.info("Unregistered module from " + serverNames[server]);
+                this.servers[server].stop();
+                logger.info("Stopped server " + serverNames[server]);
+            } catch (Throwable t) {
+                logger.info("Could not stop server", t);
+            } finally {
+                serversStarted[server] = false;
+            }
+        }
+    }
+
+    /**
+     * Stops a server with crash failure semantics (i.e. don't send out any module or topology updates)
+     *
+     * @param server the server number
+     */
+    private void crashServer(int server) {
+        if (serversStarted[server]) {
+            try {
+                this.servers[server].stop();
+                logger.info("Crashed server " + serverNames[server]);
+            } catch (Throwable t) {
+                logger.info("Could not crash server", t);
+            } finally {
+                serversStarted[server] = false;
+            }
+        }
+    }
+
+    /**
+     * Starts a server with a particular cluster topology
+     * This is required to model changes in cluster membership.
+     *
+     * @param server the server number
+     * @param startingClusterTopology the cluster topology the server should advertise when first contacted
+     * @throws Exception
+     */
+    private void startServer(int server, ClusterInfo startingClusterTopology) throws Exception {
+        servers[server] = new DummyServer("localhost", 6999 + (server * 100), serverNames[server]);
+        servers[server].start();
+        serversStarted[server] = true;
+        logger.info("Started server " + serverNames[server]);
+
+        servers[server].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
+        logger.info("Registered module on server " + servers[server]);
+
+        servers[server].addClusterNodes(startingClusterTopology);
+        logger.info("Added node to cluster " + CLUSTER_NAME + ": server " + servers[server]);
+    }
+
+    /**
+     * Stops a server with a particular cluster removal topology
+     * This is required to model changes in cluster membership.
+     *
+     * @param server the server number
+     * @param clusterRemovalTopology the cluster removal topology to convey to the client when it shuts down
+     */
+    private void stopServer(int server, ClusterTopologyListener.ClusterRemovalInfo clusterRemovalTopology) {
+        if (serversStarted[server]) {
+            try {
+                servers[server].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
+                logger.info("Unregistered module from " + serverNames[server]);
+                servers[server].removeClusterNodes(clusterRemovalTopology);
+                logger.info("Removed node from cluster " + CLUSTER_NAME + ": server " + servers[server]);
+                this.servers[server].stop();
+                logger.info("Stopped server " + serverNames[server]);
+            } catch (Throwable t) {
+                logger.info("Could not stop server", t);
+            } finally {
+                serversStarted[server] = false;
+            }
+        }
+    }
+
+    /**
+     * Do any test-specific tear down here.
+     */
+    @After
+    public void afterTest() {
+        stopServer(0, CLUSTER_REMOVE_NODE1);
+        stopServer(1, CLUSTER_REMOVE_NODE2);
+    }
+
+    /**
+     * Do any general tear down here.
+     */
+    @AfterClass
+    public static void afterClass() {
+        executorService.shutdownNow();
+    }
+
+}

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
@@ -410,4 +410,14 @@ public class DummyServer {
         mappingList.add(new MappingInfo(destHost, destPort, srcIpAddress, bytes));
         return new NodeInfo(name, mappingList);
     }
+
+    public static final ClusterRemovalInfo getClusterRemovalInfo(String name, NodeInfo... nodes) {
+        List<String> nodeList = new ArrayList<String>();
+        for (NodeInfo node : nodes) {
+            nodeList.add(node.getNodeName());
+        }
+        return new ClusterRemovalInfo(name, nodeList);
+    }
+
+
 }

--- a/src/test/resources/last-node-to-leave-jboss-ejb-client.properties
+++ b/src/test/resources/last-node-to-leave-jboss-ejb-client.properties
@@ -1,0 +1,45 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2019 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=one,two
+
+# connection to a node at protocol://host:port
+remote.connection.one.host=localhost
+remote.connection.one.port=6999
+remote.connection.one.protocol=remote
+remote.connection.one.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.one.username=test
+remote.connection.one.password=test
+remote.connection.one.realm=default
+
+# connection to a node at protocol://host:port
+remote.connection.two.host=localhost
+remote.connection.two.port=7099
+remote.connection.two.protocol=remote
+remote.connection.two.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.two.username=test
+remote.connection.two.password=test
+remote.connection.two.realm=default
+
+# the nodes are clustered in a cluster called ejb and have names node1, node2
+remote.clusters=ejb
+remote.cluster.ejb.node.node1.username=test
+remote.cluster.ejb.node.node1.password=test
+remote.cluster.ejb.clusternode.selector=org.jboss.ejb.client.test.LastNodeToLeaveTestCase$TestSelector


### PR DESCRIPTION
This PR aims to remove stale Discovered Node Registry (DNR) entries corresponding to singleton cluster nodes which are no longer available, let alone connected. This can happen when the last node of a cluster leaves, or crashes. For example, if a client invokes on a cluster with one member node1 and that member crashes, then a new member node2 joins, the client will see membership as {node1, node2} which is incorrect. This is due to the fact that the client depends on externally generated information (i.e. topology updates) to keep the DNR up to date.

For details of the fix, see: https://issues.jboss.org/browse/EJBCLIENT-325