### PR TITLE
Fix for EJBCLIENT-334 

### DIFF
--- a/src/test/java/org/jboss/ejb/client/test/common/EchoBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/EchoBean.java
@@ -40,6 +40,9 @@ public class EchoBean implements Echo {
     @Override
     public Result<String> echo(String msg) {
         logger.info(this.getClass().getSimpleName() + " echoing message " + msg);
+        if ("request to throw IllegalArgumentException".equals(msg)) {
+            throw new IllegalArgumentException("Intentionally thrown upon request from caller");
+        }
         return new Result<String>(msg, node);
     }
 


### PR DESCRIPTION
The commit here fixes the issue noted in https://issues.jboss.org/browse/EJBCLIENT-334.
Previously, in the older implementation of EJB client library we used to glue the stacktraces from the caller with the one thrown by the server side EJB. The commit here just borrows that code[1] to implement the same functionality in this new version of the library. This should solve the inconvenience noted in the forum thread[2].

The commit also includes a testcase to reproduce the issue and verify the fix.

[1] https://github.com/wildfly/jboss-ejb-client/blob/1.0/src/main/java/org/jboss/ejb/client/remoting/ProtocolMessageHandler.java#L115
[2] https://developer.jboss.org/thread/280087