### PR TITLE
[EJBCLIENT-338] Resolve hostname during discovery attempt

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
@@ -264,10 +264,10 @@ class EJBClientChannel {
                                 final CidrAddress block = CidrAddress.create(sourceIpBytes, netmaskBits);
                                 final String destHost = message.readUTF();
                                 final int destPort = message.readUnsignedShort();
-                                final InetSocketAddress destination = new InetSocketAddress(destHost, destPort);
-                                nodeInformation.addAddress(channel.getConnection().getProtocol(), clusterName, block, destination);
+                                final InetSocketAddress destUnresolved = InetSocketAddress.createUnresolved(destHost, destPort);
+                                nodeInformation.addAddress(channel.getConnection().getProtocol(), clusterName, block, destUnresolved);
                                 if (Logs.INVOCATION.isDebugEnabled()) {
-                                    Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY(%x) message block from %s, registering block %s to address %s", msg, remoteEndpoint, block, destination);
+                                    Logs.INVOCATION.debugf("Received CLUSTER_TOPOLOGY(%x) message block from %s, registering block %s to address %s", msg, remoteEndpoint, block, destUnresolved);
                                 }
                             }
                         }


### PR DESCRIPTION
@fl4via @chengfang 
Could you please take a look. This is supposed to avoid using resolved InetSocketAddresses which lead to problems in OpenShift environment.