### PR TITLE
fix for clear the failed destination cache before retry everything

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
@@ -198,7 +198,11 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
             }
         }
         // special second pass - retry everything because all were marked failed
-        if (discoveryConnections && ! ok) {
+        if (discoveryConnections && !ok) {
+            // clear the failedDestinations cache before the retry everything as all were marked as failed.
+            if (failedDestinations != null && !failedDestinations.isEmpty())
+                failedDestinations.clear();
+
             Logs.INVOCATION.tracef("EJB discovery provider: all connections marked failed, retrying ...");
             for (EJBClientConnection connection : configuredConnections) {
                 if (! connection.isForDiscovery()) {


### PR DESCRIPTION
I was investigating an issue related to the failover test when it only has two nodes. Here is the scenario.

reproduces steps:

1.	We have two node cluster, let’s take them as node1 and node2.
2.	Initially, node1 is up and running, but node2 Is down and the client is connected to the node1.
3.	Once the node2 is fully started, we have stopped node1.
4.	In this scenario, the client from the cluster disconnected and log out the user from the system.

Investigations:
1.	When node2 starting, before it is fully started, node discovery was marked node2 as failed destination and put it into the cache object.
2.	Even node2 fully started it is not removing from the cache.
3.	When node1 stopped, it also marked as a failed destination. In this situation, both nodes marked as failed from the discovery.
4.	Even the second pass happens, this failed destination cache is not clearing. But when I clear the cache as committed code in PR. Discovery was successful.

Note: when have multiple nodes, if all nodes down and one is started again, but restarted one already cached as a failed destination. it is not removing from the failed destination.