### PR TITLE
EJBCLIENT-343 add NodeSelector implementations and use it as default to prefer local node 'jboss.node.name' invocations inside of a server

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -632,8 +632,8 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         List<EJBTransportProvider> transportProviders;
         List<EJBClientConnection> clientConnections;
         List<EJBClientCluster> clientClusters;
-        ClusterNodeSelector clusterNodeSelector = ClusterNodeSelector.DEFAULT;
-        DeploymentNodeSelector deploymentNodeSelector = DeploymentNodeSelector.RANDOM;
+        ClusterNodeSelector clusterNodeSelector = ClusterNodeSelector.DEFAULT_PREFER_LOCAL;
+        DeploymentNodeSelector deploymentNodeSelector = DeploymentNodeSelector.RANDOM_PREFER_LOCAL;
         long invocationTimeout;
         int maximumConnectedClusterNodes = 10;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-343

Current default does not prefer the local server instance and this can not be forced in server or applicationconfiguration, it is only possible to exclude the local instance.