### PR TITLE
[EJBCLIENT-346] updated wildfly-client.xml to include an interceptor

### DIFF
--- a/src/main/java/org/jboss/ejb/client/ConfigurationBasedEJBClientContextSelector.java
+++ b/src/main/java/org/jboss/ejb/client/ConfigurationBasedEJBClientContextSelector.java
@@ -190,7 +190,7 @@ final class ConfigurationBasedEJBClientContextSelector {
         for (;;) {
             final int next = streamReader.nextTag();
             if (next == START_ELEMENT) {
-                if (! streamReader.getNamespaceURI().equals(NS_EJB_CLIENT_3_0) || ! streamReader.getLocalName().equals("interceptor")) {
+                if (! validNamespaces.contains(streamReader.getNamespaceURI()) || ! streamReader.getLocalName().equals("interceptor")) {
                     throw streamReader.unexpectedElement();
                 }
                 parseInterceptorType(streamReader, builder);
@@ -287,7 +287,7 @@ final class ConfigurationBasedEJBClientContextSelector {
         for (;;) {
             final int next = streamReader.nextTag();
             if (next == START_ELEMENT) {
-                if (! streamReader.getNamespaceURI().equals(NS_EJB_CLIENT_3_0)) {
+                if (! validNamespaces.contains(streamReader.getNamespaceURI())) {
                     throw streamReader.unexpectedElement();
                 }
                 final String localName = streamReader.getLocalName();
@@ -318,7 +318,7 @@ final class ConfigurationBasedEJBClientContextSelector {
         }
         final int next = streamReader.nextTag();
         if (next == START_ELEMENT) {
-            if (! streamReader.getNamespaceURI().equals(NS_EJB_CLIENT_3_0)) {
+            if (! validNamespaces.contains(streamReader.getNamespaceURI())) {
                 throw streamReader.unexpectedElement();
             }
             final String localName = streamReader.getLocalName();

--- a/src/test/java/org/jboss/ejb/client/DummyClientInterceptor.java
+++ b/src/test/java/org/jboss/ejb/client/DummyClientInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.ejb.client;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * A dummy ClientInterceptor that does nothing.
+ * It's purely for testing.
+ *
+ * @author <a href="mailto:bmaxwell@redhat.com">Brad Maxwell</a>
+ */
+public class DummyClientInterceptor implements EJBClientInterceptor {
+
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        context.sendRequest();
+    }
+
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+}

--- a/src/test/java/org/jboss/ejb/client/DummyClientInterceptor2.java
+++ b/src/test/java/org/jboss/ejb/client/DummyClientInterceptor2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.ejb.client;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * A dummy ClientInterceptor that does nothing.
+ * It's purely for testing.
+ *
+ * @author <a href="mailto:bmaxwell@redhat.com">Brad Maxwell</a>
+ */
+public class DummyClientInterceptor2 implements EJBClientInterceptor {
+
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        context.sendRequest();
+    }
+
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+}

--- a/src/test/resources/wildfly-client.xml
+++ b/src/test/resources/wildfly-client.xml
@@ -33,11 +33,17 @@
         </authentication-configurations>
     </authentication-client>
     <jboss-ejb-client xmlns="urn:jboss:wildfly-client-ejb:3.2">
+        <connections>
+            <connection uri="remote+http://127.0.0.1:8080"/>
+            <connection uri="remote+http://127.0.0.1:8180"/>
+        </connections>
         <invocation-timeout seconds="10"/>
         <deployment-node-selector class="org.jboss.ejb.client.DummyNodeSelector" />
         <cluster-node-selector class="org.jboss.ejb.client.DummyNodeSelector" />
-        <global-interceptors/>
-        <connections/>
+        <global-interceptors>
+            <interceptor class="org.jboss.ejb.client.DummyClientInterceptor"/>
+            <interceptor class="org.jboss.ejb.client.DummyClientInterceptor2"/>
+        </global-interceptors>
         <max-allowed-connected-nodes nodes="15"/>
     </jboss-ejb-client>
 </configuration>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/EJBCLIENT-346

    [EJBCLIENT-346] updated wildfly-client.xml to include an interceptor for test coverage, fixed ConfigurationBasedEJBClientContextSelector to check valid namespaces instead of just the 3.0 as the 3.1 namespace handles everything in the 3.0
