### PR TITLE
EJBCLIENT-350 Use the correst XML namespace for wildfly-client-ejb 3.2 xsd

### DIFF
--- a/src/main/resources/schema/wildfly-client-ejb_3_2.xsd
+++ b/src/main/resources/schema/wildfly-client-ejb_3_2.xsd
@@ -19,8 +19,8 @@
   -->
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="urn:jboss:wildfly-client-ejb:3.1"
-            xmlns="urn:jboss:wildfly-client-ejb:3.1"
+            targetNamespace="urn:jboss:wildfly-client-ejb:3.2"
+            xmlns="urn:jboss:wildfly-client-ejb:3.2"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.0">


### PR DESCRIPTION
The commit here updates the `wildfly-client-ejb:3.2` xsd to use the correct XML namespace. This should fix the issue reported in https://issues.jboss.org/browse/EJBCLIENT-350