### PR TITLE
[EJBCLIENT-351] Enhance XNIO error logging for RemoteEJBReceiver, cha…

### DIFF
--- a/src/test/java/org/jboss/ejb/client/test/OOMEInInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/OOMEInInvocationTestCase.java
@@ -84,7 +84,7 @@ public class OOMEInInvocationTestCase extends AbstractEJBClientTestCase {
     @Test
     public void testSLSBInvocation() {
         
-        Assert.assertEquals("echo system property exists", System.getProperty("echo"), null);
+        Assert.assertEquals("echo system property exists", null, System.getProperty("echo"));
         
         Affinity expectedStrongAffinity = Affinity.NONE;
         
@@ -102,7 +102,7 @@ public class OOMEInInvocationTestCase extends AbstractEJBClientTestCase {
             //don't do anything, it is expected
         }
         // check the property contents
-        Assert.assertEquals("method echo not in error message", System.getProperty("echo"), "true");
+        Assert.assertEquals("method echo not in error message", "true", System.getProperty("echo"));
     }
 
     /**


### PR DESCRIPTION
…nge parameter order

Issue: https://issues.jboss.org/browse/EJBCLIENT-351

Related issue: https://issues.jboss.org/browse/XNIO-348

The test will fail until XNIO version is updated, this PR changes the AssertEquals parameter order

PR master: #419 (previous)
PR 4.0: https://github.com/wildfly/jboss-ejb-client/pull/422
