### PR TITLE
EJBCLIENT-343 EJB invocation will not stay local if the application is deployed in a local serer and the Remote interface is used

### DIFF
--- a/src/main/java/org/jboss/ejb/client/ClusterNodeSelector.java
+++ b/src/main/java/org/jboss/ejb/client/ClusterNodeSelector.java
@@ -24,16 +24,18 @@ import java.util.HashSet;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jboss.ejb._private.Logs;
 import org.wildfly.common.Assert;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * A selector which selects and returns a node from the available nodes in a cluster. Typical usage of a
  * {@link ClusterNodeSelector} involve load balancing of calls to various nodes in the cluster.
  *
  * @author Jaikiran Pai
+ * @author <a href="mailto:wfink@redhat.com">Wolf Dieter Fink</a>
  */
 public interface ClusterNodeSelector {
-
     /**
      * Returns a node from among the {@code totalAvailableNodes}, as the target node for EJB invocations.
      * The selector can decide whether to pick an already connected node (from the passed {@code connectedNodes})
@@ -68,10 +70,63 @@ public interface ClusterNodeSelector {
     ClusterNodeSelector RANDOM = (clusterName, connectedNodes, totalAvailableNodes) -> totalAvailableNodes[ThreadLocalRandom.current().nextInt(totalAvailableNodes.length)];
 
     /**
+     * Use available nodes in a round-robin fashion, regardless of whether it is connected.
+     */
+    ClusterNodeSelector ROUND_ROBIN = new ClusterNodeSelector() {
+        private final AtomicInteger count = new AtomicInteger();
+        public String selectNode(final String clusterName, final String[] connectedNodes, final String[] totalAvailableNodes) {
+            assert totalAvailableNodes.length != 0;
+            return totalAvailableNodes[Math.floorMod(count.getAndIncrement(), totalAvailableNodes.length)];
+        }
+    };
+
+    /**
      * A simple default selector which uses {@link #simpleConnectionThresholdRandomSelector(int)} with a minimum of
      * 5 connections.
      */
     ClusterNodeSelector DEFAULT = simpleConnectionThresholdRandomSelector(5);
+
+    /**
+     * A deployment node selector which check the server name if inside and prefer it if available for selection.
+     * If no local node is used the DEFAULT will be used and connect a minimum of 5 nodes and select it randomly.
+     */
+  ClusterNodeSelector DEFAULT_PREFER_LOCAL = new ClusterNodeSelector() {
+      private final String localNodeName = WildFlySecurityManager.getPropertyPrivileged("jboss.node.name", null);
+
+		public String selectNode(String clusterName, String[] connectedNodes, String[] totalAvailableNodes) {
+          // Check if more than one node is available
+          if (totalAvailableNodes.length > 1 && localNodeName != null) {
+	            for (final String node : totalAvailableNodes) {
+	                if (localNodeName.equals(node)) {
+                      if (Logs.MAIN.isDebugEnabled()) {
+	                        Logs.MAIN.debugf("Select local node %s for [cluster: %s]", this.localNodeName, clusterName);
+                      }
+	                    return node;
+	                }
+	            }
+          }
+          return DEFAULT.selectNode(clusterName, connectedNodes, totalAvailableNodes);
+      }
+	};
+
+    ClusterNodeSelector RANDOM_PREFER_LOCAL = new ClusterNodeSelector() {
+        private final String localNodeName = WildFlySecurityManager.getPropertyPrivileged("jboss.node.name", null);
+
+		public String selectNode(String clusterName, String[] connectedNodes, String[] totalAvailableNodes) {
+	          // Check if more than one node is available
+            if (totalAvailableNodes.length > 1 && localNodeName != null) {
+	            for (final String node : totalAvailableNodes) {
+	                if (localNodeName.equals(node)) {
+                      if (Logs.MAIN.isDebugEnabled()) {
+	                        Logs.MAIN.debugf("Select local node %s for [cluster: %s]", this.localNodeName, clusterName);
+                      }
+	                    return node;
+	                }
+	            }
+            }
+            return RANDOM.selectNode(clusterName, connectedNodes, totalAvailableNodes);
+        }
+    };
 
     /**
      * A simple threshold-based random selector.  If the minimum is met, then a random connected node is used, otherwise

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -675,8 +675,8 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         List<EJBTransportProvider> transportProviders;
         List<EJBClientConnection> clientConnections;
         List<EJBClientCluster> clientClusters;
-        ClusterNodeSelector clusterNodeSelector = ClusterNodeSelector.DEFAULT;
-        DeploymentNodeSelector deploymentNodeSelector = DeploymentNodeSelector.RANDOM;
+        ClusterNodeSelector clusterNodeSelector = ClusterNodeSelector.DEFAULT_PREFER_LOCAL;
+        DeploymentNodeSelector deploymentNodeSelector = DeploymentNodeSelector.RANDOM_PREFER_LOCAL;
         long invocationTimeout;
         int maximumConnectedClusterNodes = 10;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-343

Current default does not prefer the local server instance and this can not be forced in server or applicationconfiguration, it is only possible to exclude the local instance.
