### PR TITLE
[EJBCLIENT-358] Add -Djdk.attach.allowAttachSelf arg to surefire to m…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
                             <value>org.jboss.logmanager.LogManager</value>
                         </property>
                     </systemProperties>
+                     <argLine>-Djdk.attach.allowAttachSelf</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
…ake Byteman tests run in JDK9+

https://issues.jboss.org/browse/EJBCLIENT-358