### PR TITLE
[EJBCLIENT-281] RequestSendFailedException extends EJBException

### DIFF
--- a/src/main/java/org/jboss/ejb/client/RequestSendFailedException.java
+++ b/src/main/java/org/jboss/ejb/client/RequestSendFailedException.java
@@ -1,11 +1,13 @@
 package org.jboss.ejb.client;
 
+import javax.ejb.EJBException;
+
 /**
  * An exception (typically) thrown by {@link EJBReceiver}s if the receiver couldn't successfully handle a request.
  *
  * @author: Jaikiran Pai
  */
-public class RequestSendFailedException extends RuntimeException {
+public class RequestSendFailedException extends EJBException {
 
     /**
      * The node name of the EJB receiver which failed to handle the request
@@ -18,7 +20,8 @@ public class RequestSendFailedException extends RuntimeException {
      * @param cause          The exception which caused this failure
      */
     public RequestSendFailedException(final String failedNodeName, final String failureMessage, final Throwable cause) {
-        super(failureMessage, cause);
+        super(failureMessage);
+        initCause(cause);
         this.failedNodeName = failedNodeName;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/EJBCLIENT-281
4.0.x added this change which causes compatibility issue, might also should apply the change to 
the other branches.  tadamski mentioned we might consider reverting this in the 4.0 branch.  We need to decide how to fix it without breaking anything else if this is required.