### PR TITLE
[EJBCLIENT-380] Update to catch correct exception class

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/RemoteEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemoteEJBReceiver.java
@@ -51,6 +51,7 @@ import org.wildfly.common.annotation.NotNull;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
+import org.xnio.http.ConnectionClosedEarlyException;
 import org.xnio.http.HttpUpgrade;
 import org.xnio.http.UpgradeFailedException;
 
@@ -105,7 +106,7 @@ class RemoteEJBReceiver extends EJBReceiver {
         public void handleFailed(final IOException exception, final EJBReceiverInvocationContext attachment) {
             URI destination = attachment.getClientInvocationContext().getDestination();
             if (exception instanceof UpgradeFailedException ||
-               exception instanceof HttpUpgrade.ConnectionClosedEarlyException) {
+               exception instanceof ConnectionClosedEarlyException) {
                 Logs.REMOTING.error("Error in connecting to " + destination + " : Please check if the client and server are configured to use the same protocol and ports.");
             } else if (exception instanceof SSLException && exception.getMessage().equals("Unrecognized SSL message, plaintext connection?")) {
                 Logs.REMOTING.error("Error in connecting to " + destination + " : The destination doesn't support SSL. Did you mean to use http protocol instead?");


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/EJBCLIENT-380

@tadamski this is a follow up to #466 due to the exception HttpUpgrade.ConnectionClosedEarlyException having been moved to a separate top level class in XNIO review.