### PR TITLE
EJBCLIENT-388 remote+tls is not supported by EJBClient and remote-outbou…

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/RemoteTransportProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemoteTransportProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2017 Red Hat, Inc., and individual contributors
+ * Copyright 2020 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,6 +50,7 @@ public final class RemoteTransportProvider implements EJBTransportProvider {
     public boolean supportsProtocol(final String uriScheme) {
         switch (uriScheme) {
             case "remote":
+            case "remote+tls":
             case "remote+http":
             case "remote+https":
             // compatibility
@@ -67,6 +68,7 @@ public final class RemoteTransportProvider implements EJBTransportProvider {
     public EJBReceiver getReceiver(final EJBReceiverContext receiverContext, final String uriScheme) throws IllegalArgumentException {
         switch (uriScheme) {
             case "remote":
+            case "remote+tls":
             case "remote+http":
             case "remote+https":
             // compatibility


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/EJBCLIENT-388
Related WildFly Issue: https://issues.redhat.com/browse/WFLY-13828
Other related wildfly-core PR for the same issue: [#4349](https://github.com/wildfly/wildfly-core/pull/4349)