### PR TITLE
EJBCLIENT-356 use eagerNodes mechanism for faster discovery result on…

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -199,6 +199,15 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
         return sessionID;
     }
 
+    /**
+     * Gets the value (in milliseconds) of discovery additional timeout,
+     * configured with system property {@code org.jboss.ejb.client.discovery.additional-node-timeout}.
+     *
+     * @return the value (in milliseconds) of discovery additional timeout
+     */
+    public static long getDiscoveryAdditionalTimeout() {
+        return DISCOVERY_ADDITIONAL_TIMEOUT;
+    }
 
     /**
      * Intended to be called by interceptors which assign a new destination


### PR DESCRIPTION
…ly when org.jboss.ejb.client.discovery.additional-node-timeout sysprop is set

JIRA: https://issues.redhat.com/browse/EJBCLIENT-356
Related: https://issues.redhat.com/browse/WFLY-13956