### PR TITLE
[EJBCLIENT-393] Fixing the situation where the remote client want's connect to ServerA …

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
@@ -496,7 +496,9 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
                             }
                         }
                         outer: for (NodeInformation information : nodes.values()) {
-                            for (NodeInformation.ClusterNodeInformation cni : information.getClustersByName().values()) {
+                            for (Map.Entry<String, NodeInformation.ClusterNodeInformation> entry : information.getClustersByName().entrySet()) {
+                                String clusterName = entry.getKey();
+                                NodeInformation.ClusterNodeInformation cni = entry.getValue();
                                 final Map<String, CidrAddressTable<InetSocketAddress>> atm = cni.getAddressTablesByProtocol();
                                 for (Map.Entry<String, CidrAddressTable<InetSocketAddress>> entry2 : atm.entrySet()) {
                                     final String protocol = entry2.getKey();
@@ -517,11 +519,7 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
                                                     }
                                                 }
                                                 URI location = new URI(protocol, null, hostName, destination.getPort(), null, null, null);
-                                                String cluster = effectiveAuthMappings.get(location);
-                                                if (cluster != null) {
-                                                    effectiveAuthMappings.put(location, cluster);
-                                                }
-
+                                                effectiveAuthMappings.put(location, clusterName);
                                                 everything.add(location);
                                                 continue outer;
                                             }


### PR DESCRIPTION
… as a discovery host (where the requiered application is missing), but application it is on a different ServerB within the cluster.

effectiveAuthMappings was empty, therefore the attempt to connnect remote client to ServerB was unsuccessful, because lack of proper authentication settings ended with an error.