### PR TITLE
EJBCLIENT-398 Implement additional timeout also for cluster discovery

### DIFF
--- a/src/test/java/org/jboss/ejb/client/test/NetworkBlackHoleInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/NetworkBlackHoleInvocationTestCase.java
@@ -20,143 +20,149 @@ package org.jboss.ejb.client.test;
 import static org.jboss.ejb._private.SystemProperties.DISCOVERY_ADDITIONAL_NODE_TIMEOUT;
 import static org.jboss.ejb._private.SystemProperties.DISCOVERY_TIMEOUT;
 
+import org.jboss.ejb.client.Affinity;
+import org.jboss.ejb.client.ClusterAffinity;
 import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBLocator;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.ejb.client.legacy.JBossEJBProperties;
-import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.Echo;
-import org.jboss.ejb.client.test.common.EchoBean;
 import org.jboss.ejb.client.test.common.Result;
 import org.jboss.logging.Logger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
 /**
+ * Tests discovery timeout configuration.
+ *
  * @author <a href="ingo@redhat.com">Ingo Weiss</a>
+ * @author <a href="thofman@redhat.com">Tomas Hofman</a>
  */
-public class NetworkBlackHoleInvocationTestCase {
+public class NetworkBlackHoleInvocationTestCase extends AbstractEJBClientTestCase {
+
     private static final Logger logger = Logger.getLogger(NetworkBlackHoleInvocationTestCase.class);
     private static final String PROPERTIES_FILE = "broken-server-jboss-ejb-client.properties";
 
-    private DummyServer server;
-    private boolean serverStarted = false;
-
-    // module
-    private static final String APP_NAME = "my-foo-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    private static final String SERVER_NAME = "test-server";
-
-    /**
-     * Do any general setup here
-     *
-     * @throws Exception
-     */
     @BeforeClass
     public static void beforeClass() throws Exception {
         // trigger the static init of the correct properties file - this also depends on running in forkMode=always
-        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(NetworkBlackHoleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
+        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(SimpleInvocationTestCase.class.getClassLoader(), PROPERTIES_FILE);
         JBossEJBProperties.getContextManager().setGlobalDefault(ejbProperties);
-    }
 
-    /**
-     * Do any test specific setup here
-     */
-    @Before
-    public void beforeTest() throws Exception {
-        // start a server
-        server = new DummyServer("localhost", 6999, SERVER_NAME);
-        server.start();
-        serverStarted = true;
-        logger.info("Started server ...");
-        serverStarted = true;
-
-        server.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
-        logger.info("Registered module ...");
-    }
-
-    /**
-     * Do any test-specific tear down here.
-     */
-    @After
-    public void afterTest() {
-        server.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-        logger.info("Unregistered module ...");
-
-        if (serverStarted) {
-            try {
-                this.server.stop();
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            }
-        }
-        logger.info("Stopped server ...");
-    }
-
-    /**
-     * Test a failed client discovery
-     */
-    @Test
-    public void testTakingDownServerDoesNotBreakClients() throws Exception {
+        // set discovery timeouts
 
         // broken-server-jboss-ejb-client.properties will have the ejb-client with 2 nodes on ports 6999 and 7099
         // it will succesfully invoke the ejb and then it will kill the 7099 port and try to invoke again
-        // the expected behavior is that it will not wait more than DISCOVERY_ADDITIONAL_NODE_TIMEOUT once it has a connection to 6999 before invoking the ejb
+        // the expected behavior is that it will not wait more than org.jboss.ejb.client.discovery.additional-node-timeout once it has a connection to 6999 before invoking the ejb
         System.setProperty(DISCOVERY_TIMEOUT, "10");
 
-        // This test will fail if DISCOVERY_ADDITIONAL_NODE_TIMEOUT is not set
-        // assertInvocationTimeLessThan checks that the DISCOVERY_ADDITIONAL_NODE_TIMEOUT is effective
-        // if DISCOVERY_ADDITIONAL_NODE_TIMEOUT is not effective it will timeout once it reaches the value of DISCOVERY_TIMEOUT
-        System.setProperty(DISCOVERY_ADDITIONAL_NODE_TIMEOUT, "2");
+        // This test will fail if org.jboss.ejb.client.discovery.additional-node-timeout is not set
+        // assertInvocationTimeLessThan checks that the org.jboss.ejb.client.discovery.additional-node-timeout is effective
+        // if org.jboss.ejb.client.discovery.additional-node-timeout is not effective it will timeout once it reaches the value of org.jboss.ejb.client.discovery.timeout
+        System.setProperty(DISCOVERY_ADDITIONAL_NODE_TIMEOUT, "200");
+    }
 
-        try (DummyServer server2 = new DummyServer("localhost", 7099, "test2")) {
-            server2.start();
-            server2.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(DISCOVERY_TIMEOUT);
+        System.clearProperty(DISCOVERY_ADDITIONAL_NODE_TIMEOUT);
+    }
 
-            // create a proxy for invocation
-            final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<>
-                    (Echo.class, APP_NAME, MODULE_NAME, Echo.class.getSimpleName(), DISTINCT_NAME);
-            final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
-            Assert.assertNotNull("Received a null proxy", proxy);
-            logger.info("Created proxy for Echo: " + proxy.toString());
+    @Before
+    public void beforeTest() throws Exception {
+        startServer(0, 6999);
+        startServer(1, 7099);
 
-            logger.info("Invoking on proxy...");
-            // Invoke on the proxy. This should fail in 10 seconds or else it'll hang.
-            final String message = "hello!";
+        deployStateless(0);
+        deployStateless(1);
 
-            long invocationStart = System.currentTimeMillis(); 
-            Result<String> echo = proxy.echo(message);
-            assertInvocationTimeLessThan(DISCOVERY_ADDITIONAL_NODE_TIMEOUT + " ineffective", 3000, invocationStart);
-            Assert.assertEquals(message, echo.getValue());
-            server2.hardKill();
+        // define clusters
+        defineCluster(0, CLUSTER);
+        defineCluster(1, CLUSTER);
+    }
 
-            final Echo proxy2 = EJBClient.createProxy(statelessEJBLocator);
-            Assert.assertNotNull("Received a null proxy", proxy2);
-            logger.info("Created proxy for Echo: " + proxy2.toString());
+    @After
+    public void afterTest() {
+        // wipe cluster
+        removeCluster(0, CLUSTER_NAME);
+        removeCluster(1, CLUSTER_NAME);
 
-            //this is a network black hole
-            //it emulates what happens if the server just disappears, and connect attempts hang
-            //instead of being immediately rejected (e.g. a firewall dropping packets)
-            try (ServerSocket s = new ServerSocket(7099, 100, InetAddress.getByName("localhost"))) {
-                invocationStart = System.currentTimeMillis(); 
-                echo = proxy2.echo(message);
-                assertInvocationTimeLessThan(DISCOVERY_ADDITIONAL_NODE_TIMEOUT + " ineffective", 3000, invocationStart);
-                Assert.assertEquals(message, echo.getValue());
-            }
+        undeployStateless(0);
+        undeployStateless(1);
+
+        stopServer(0);
+        stopServer(1);
+    }
+
+    /**
+     * Tests that node discovery times out after additional-node-timeout, after the first node has been discovered.
+     *
+     * This method tests the use case when affinity is None.
+     *
+     * If the test method timed out, then the additional-node-timeout system property didn't take effect.
+     */
+    @Test(timeout = 4000)
+    public void testDiscoveryTimeoutWithoutAffinity() throws Exception {
+        final StatelessEJBLocator<Echo> locator = StatelessEJBLocator.create(Echo.class, STATELESS_IDENTIFIER,
+                Affinity.NONE);
+
+        // verify that client invocation works when both nodes are responsive
+        verifyClient(locator);
+
+        // stop second node and open a socket at the same port to simulate unresponsive node
+        stopServer(1);
+        try (ServerSocket s = new ServerSocket(7099, 100, InetAddress.getByName("localhost"))) {
+            verifyClient(locator);
         }
+    }
+
+    /**
+     * Tests that node discovery times out after additional-node-timeout, after the first node has been discovered.
+     *
+     * This method tests the use case when affinity is ClusterAffinity.
+     *
+     * If the test method timed out, then additional-node-timeout system property didn't take effect.
+     */
+    @Test(timeout = 4000)
+    public void testDiscoveryTimeoutWithClusterAffinity() throws Exception {
+        final StatelessEJBLocator<Echo> locator = StatelessEJBLocator.create(Echo.class, STATELESS_IDENTIFIER,
+                new ClusterAffinity(CLUSTER_NAME));
+
+        // verify that client invocation works when both nodes are responsive
+        verifyClient(locator);
+
+        // stop second node and open a socket at the same port to simulate an unresponsive node
+        stopServer(1);
+        try (ServerSocket s = new ServerSocket(7099, 100, InetAddress.getByName("localhost"))) {
+            verifyClient(locator);
+        }
+    }
+
+    private static void verifyClient(EJBLocator<Echo> locator) {
+        final Echo proxy = EJBClient.createProxy(locator);
+        Assert.assertNotNull("Received a null proxy", proxy);
+        logger.info("Created proxy for Echo: " + proxy.toString());
+
+        logger.info("Invoking on proxy...");
+        // Invoke on the proxy. This should fail in 10 seconds or else it'll hang.
+        final String message = "hello!";
+
+        long invocationStart = System.currentTimeMillis();
+        Result<String> echo = proxy.echo(message);
+        assertInvocationTimeLessThan("org.jboss.ejb.client.discovery.additional-node-timeout ineffective", 3000, invocationStart);
+        Assert.assertEquals(message, echo.getValue());
     }
 
     private static void assertInvocationTimeLessThan(String message, long maximumInvocationTimeMs, long invocationStart) {
         long invocationTime = System.currentTimeMillis() - invocationStart;
-        if(invocationTime > maximumInvocationTimeMs)
+        if (invocationTime > maximumInvocationTimeMs)
             Assert.fail(String.format("%s: invocation time: %d > maximum expected invocation time: %d", message, invocationTime, maximumInvocationTimeMs));
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/EJBCLIENT-398
Downstream Issue: https://issues.redhat.com/browse/JBEAP-20666

The "discovery.additional-timeout" was implemented previously in DiscoveryEJBClientInterceptor#doAnyDiscovery(). This PR implements the same functionality for cluster discovery.