### PR TITLE
[EJBCLIENT-402] Convert some remaining test cases to use AbstractEJBClientTestCase

### DIFF
--- a/src/test/java/org/jboss/ejb/client/test/AbstractEJBClientTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/AbstractEJBClientTestCase.java
@@ -46,14 +46,14 @@ public class AbstractEJBClientTestCase {
     public DummyServer[] servers = new DummyServer[NUM_SERVERS];
     public static boolean[] serversStarted = new boolean[NUM_SERVERS] ;
 
-    // module
+    // modules
     public static final String APP_NAME = "my-foo-app";
     public static final String OTHER_APP = "my-other-app";
     public static final String MODULE_NAME = "my-bar-module";
     public static final String DISTINCT_NAME = "";
 
-    // cluster
-    // note: logical node names and server names should match!
+    // clusters
+    // note: node names and server names should match!
     public static final String CLUSTER_NAME = "ejb";
     public static final String NODE1_NAME = "node1";
     public static final String NODE2_NAME = "node2";
@@ -64,16 +64,33 @@ public class AbstractEJBClientTestCase {
     public static final ClusterTopologyListener.NodeInfo NODE2 = DummyServer.getNodeInfo(NODE2_NAME, "localhost",7099,"0.0.0.0",0);
     public static final ClusterTopologyListener.NodeInfo NODE3 = DummyServer.getNodeInfo(NODE3_NAME, "localhost",7199,"0.0.0.0",0);
     public static final ClusterTopologyListener.NodeInfo NODE4 = DummyServer.getNodeInfo(NODE4_NAME, "localhost",7299,"0.0.0.0",0);
-    public static final ClusterTopologyListener.ClusterInfo CLUSTER = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
+    public static final ClusterTopologyListener.ClusterInfo CLUSTER_2_NODES = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2);
+    public static final ClusterTopologyListener.ClusterInfo CLUSTER_3_NODES = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2, NODE3);
+    public static final ClusterTopologyListener.ClusterInfo CLUSTER_4_NODES = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1, NODE2, NODE3, NODE4);
+    // most common case
+    public static final ClusterTopologyListener.ClusterInfo CLUSTER = CLUSTER_2_NODES;
 
-    // convenience
+    // convenience identifiers
     public final EJBModuleIdentifier MODULE_IDENTIFIER = new EJBModuleIdentifier(APP_NAME, MODULE_NAME, DISTINCT_NAME);
     public final EJBModuleIdentifier OTHER_MODULE_IDENTIFIER = new EJBModuleIdentifier(OTHER_APP, MODULE_NAME, DISTINCT_NAME);
     public final EJBIdentifier STATELESS_IDENTIFIER = new EJBIdentifier(MODULE_IDENTIFIER,StatelessEchoBean.class.getSimpleName());
     public final EJBIdentifier STATEFUL_IDENTIFIER = new EJBIdentifier(MODULE_IDENTIFIER,StatefulEchoBean.class.getSimpleName());
 
+    //
+    // start(), stop() servers
+    // - these methods are used to model the following scenarios
+    //   - starting and stopping up to 4 servers using host={localhost} and port={6999, 7199, 7299, 7399}
+    //
 
-    /* start a server with hostname = localhost" and Remoting Transaction service enabled*/
+    public void startServer(int index) throws Exception {
+        startServer(index, false);
+    }
+
+    public void startServer(int index, boolean startTxService) throws Exception {
+        startServer(index, 6999 + (index*100), startTxService);
+    }
+
+    // deprecate
     public void startServer(int index, int port) throws Exception {
         startServer(index, port, false);
     }
@@ -116,14 +133,33 @@ public class AbstractEJBClientTestCase {
         }
     }
 
+    /*
+    public void killServer(int server) {
+        if (serversStarted[server]) {
+            try {
+                this.servers[server].hardKill();
+                logger.info("Killed server " + serverNames[server]);
+            } catch (Throwable t) {
+                logger.info("Could not kill server", t);
+            } finally {
+                serversStarted[server] = false;
+            }
+        }
+    }
+    */
+
     public static boolean isServerStarted(int index) {
         return serversStarted[index];
     }
 
-    /*
-     * bean deployment helpers for generic beans StatefulEchoBean, StatelessEchoBean in module "my-foo-app"/"my-bar-module"
-     */
 
+    //
+    // deploy(), undeploy() modules
+    // - these methods are used to model the following scenarios:
+    //   - deploy and undeploy a generic stateful or stateless bean in module named APP_NAME/MODULE_NAME/DISTINCT_NAME
+    //   - deploy and undeploy a generic stateful or stateless bean in module named OTHER_APP/MODULE_NAME/DISTINCT_NAME
+    //
+    //
     public void deployStateless(int index) {
         servers[index].register(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatelessEchoBean.class.getSimpleName(), new StatelessEchoBean(serverNames[index]));
         logger.info("Registered SLSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
@@ -142,27 +178,6 @@ public class AbstractEJBClientTestCase {
     public void undeployStateful(int index) {
         servers[index].unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, StatefulEchoBean.class.getSimpleName());
         logger.info("Unregistered SFSB module " + MODULE_IDENTIFIER.toString()  + " on server " + serverNames[index]);
-    }
-
-
-    public void defineCluster(int index, ClusterTopologyListener.ClusterInfo cluster) {
-        servers[index].addCluster(cluster);
-        logger.info("Added node to cluster " + cluster + ": server " + servers[index]);
-    }
-
-    public void addClusterNodes(int index, ClusterTopologyListener.ClusterInfo cluster) {
-        servers[index].addClusterNodes(cluster);
-        logger.info("Added node(s) to cluster " + cluster + ":" + cluster.getNodeInfoList());
-    }
-
-    public void removeClusterNodes(int index, ClusterTopologyListener.ClusterRemovalInfo cluster) {
-        servers[index].removeClusterNodes(cluster);
-        logger.info("Removed node(s) from cluster " + cluster + ":" + cluster.getNodeNames());
-    }
-
-    public void removeCluster(int index, String clusterName) {
-        servers[index].removeCluster(clusterName);
-        logger.info("Removed cluster " + clusterName + " from node: server " + servers[index]);
     }
 
     public void deployOtherStateless(int index) {
@@ -195,4 +210,36 @@ public class AbstractEJBClientTestCase {
         logger.info("Unregistered custom bean " + (new EJBModuleIdentifier(app, module, distinct)).toString()  + " on server " + serverNames[index]);
     }
 
+    //
+    // manage clusters
+    // - when we want to model nodes which are also clustered, we need to use these methods to describe the clusters a node has joined
+    // - the methods affect generation of topology updates and module updates sent by the DummyServer instances back to the client
+    // - operations are available to:
+    //   - define a cluster and its member nodes
+    //   - add nodes to a defined cluster
+    //   - remove nodes from a defined cluster
+    //   - remove a cluster and all of its defined nodes
+    // - it is important to realise that these methods apply on a server by server basis; in other words,
+    //   if we want to represent the fact that there is a cluster called 'myCluster' with members 'myNode1' and 'myNode2' in the test, we need to
+    //   set up that representation on each node separately
+
+    public void defineCluster(int index, ClusterTopologyListener.ClusterInfo cluster) {
+        servers[index].addCluster(cluster);
+        logger.info("Added node to cluster " + cluster + ": server " + servers[index]);
+    }
+
+    public void addClusterNodes(int index, ClusterTopologyListener.ClusterInfo cluster) {
+        servers[index].addClusterNodes(cluster);
+        logger.info("Added node(s) to cluster " + cluster + ":" + cluster.getNodeInfoList());
+    }
+
+    public void removeClusterNodes(int index, ClusterTopologyListener.ClusterRemovalInfo cluster) {
+        servers[index].removeClusterNodes(cluster);
+        logger.info("Removed node(s) from cluster " + cluster + ":" + cluster.getNodeNames());
+    }
+
+    public void removeCluster(int index, String clusterName) {
+        servers[index].removeCluster(clusterName);
+        logger.info("Removed cluster " + clusterName + " from node: server " + servers[index]);
+    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationFailOverTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/ClusteredInvocationFailOverTestCase.java
@@ -21,9 +21,11 @@ import org.jboss.ejb.client.ClusterAffinity;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.ejb.client.legacy.JBossEJBProperties;
+import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.Echo;
 import org.jboss.ejb.client.test.common.Result;
 import org.jboss.ejb.client.test.common.StatelessEchoBean;
+import org.jboss.ejb.server.ClusterTopologyListener;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -32,16 +34,28 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.ejb.EJBException;
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.Assert.fail;
+
 /**
- * Tests basic invocation of a bean deployed on a single server node.
+ * Tests fail-over of the EJB client invocation mechanism.
+ *
+ * NOTE: When shutting down a server, if this happens during discovery, we can have trouble:
+ * - we shut down the server A
+ * - discovery tries to contact all known nodes {A,B}; gets a channel closed exception
+ * - discovery cannot reach node A
+ * - topology update arrives which excludes A from available nodes
  *
  * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
@@ -50,12 +64,18 @@ public class ClusteredInvocationFailOverTestCase extends AbstractEJBClientTestCa
     public static AtomicInteger SENT = new AtomicInteger();
 
     private static final Logger logger = Logger.getLogger(ClusteredInvocationFailOverTestCase.class);
-    private static final String PROPERTIES_FILE = "clustered-jboss-ejb-client.properties";
+    private static final String PROPERTIES_FILE = "jboss-ejb-client.properties";
 
-    private static final int THREADS = 40;
+    private static final int THREADS = 1;
+
+    public static final ClusterTopologyListener.ClusterRemovalInfo removal = DummyServer.getClusterRemovalInfo(CLUSTER_NAME, NODE1);
+    public static final ClusterTopologyListener.ClusterInfo addition = DummyServer.getClusterInfo(CLUSTER_NAME, NODE1);
 
     private static ExecutorService executorService;
     private volatile boolean runInvocations = true;
+
+    Map<String, AtomicInteger> twoNodesUp = new HashMap<String, AtomicInteger>();
+    Map<String, AtomicInteger> oneNodeUp = new HashMap<String, AtomicInteger>();
 
     /**
      * Do any general setup here
@@ -75,9 +95,14 @@ public class ClusteredInvocationFailOverTestCase extends AbstractEJBClientTestCa
      */
     @Before
     public void beforeTest() throws Exception {
-
-        //startServer(0);
-        startServerAndDeploy(1);
+        // start a cluster of two nodes
+        for (int i = 0; i < 2; i++) {
+            startServer(i);
+            deployStateless(i);
+            defineCluster(i, CLUSTER);
+        }
+        twoNodesUp.clear();
+        oneNodeUp.clear();
     }
 
 
@@ -89,67 +114,111 @@ public class ClusteredInvocationFailOverTestCase extends AbstractEJBClientTestCa
         List<Future<?>> retList = new ArrayList<>();
 
         for(int i = 0; i < THREADS; ++i) {
+            // set up THREADs number of invocation loops
             retList.add(executorService.submit((Callable<Object>) () -> {
                 while (runInvocations) {
-                    final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, StatelessEchoBean.class.getSimpleName(), DISTINCT_NAME);
-                    final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+                    try {
+                        final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, APP_NAME, MODULE_NAME, StatelessEchoBean.class.getSimpleName(), DISTINCT_NAME);
+                        final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
 
-                    EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
-                    Assert.assertNotNull("Received a null proxy", proxy);
-                    logger.info("Created proxy for Echo: " + proxy.toString());
+                        EJBClient.setStrongAffinity(proxy, new ClusterAffinity("ejb"));
+                        Assert.assertNotNull("Received a null proxy", proxy);
+                        logger.info("Created proxy for Echo: " + proxy.toString());
 
-                    logger.info("Invoking on proxy...");
-                    // invoke on the proxy (use a ClusterAffinity for now)
-                    final String message = "hello!";
-                    SENT.incrementAndGet();
-                    final Result<String> echoResult = proxy.echo(message);
-                    Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+                        logger.info("Invoking on proxy...");
+                        // invoke on the proxy (use a ClusterAffinity for now)
+                        final String message = "hello!";
+                        SENT.incrementAndGet();
+                        final Result<String> echoResult = proxy.echo(message);
+                        Assert.assertEquals("Got an unexpected echo", echoResult.getValue(), message);
+
+                        // increment the invocation count
+                        if (isServerStarted(0) && isServerStarted(1)) {
+                            synchronized (twoNodesUp) {
+                                String node = echoResult.getNode();
+                                AtomicInteger hits = twoNodesUp.get(node);
+                                if (hits == null) {
+                                    twoNodesUp.put(node, new AtomicInteger(0));
+                                    hits = twoNodesUp.get(node);
+                                }
+                                hits.getAndIncrement();
+                                logger.info("invocation on two nodes hit node: " + node);
+                            }
+                        } else if (isServerStarted(1)) {
+                            synchronized (oneNodeUp) {
+                                String node = echoResult.getNode();
+                                AtomicInteger hits = oneNodeUp.get(node);
+                                if (hits == null) {
+                                    oneNodeUp.put(node, new AtomicInteger(0));
+                                    hits = oneNodeUp.get(node);
+                                }
+                                hits.getAndIncrement();
+                                logger.info("invocation on one nodes hit node: " + node);
+                            }
+                        } else {
+                            fail("Invocation hit unreachable target");
+                        }
+
+                    } catch(Exception e) {
+                        if (e instanceof EJBException && e.getCause() instanceof ClosedChannelException) {
+                            // this is expected when we shut the server down asynchronously during an invocation
+                        } else {
+                            Thread.dumpStack();
+                            fail("Invocation failed with exception " + e.toString());
+                        }
+                    }
                 }
                 return "ok";
             }));
         }
 
+        // invoke
         Thread.sleep(500);
-        stopServer(0);
-        //startServer(0);
-        //Thread.sleep(500);
-        //stopServer(1);
 
+        // stop a server and update the topology of the remaining node
+        logger.info("Stopping server: " + serverNames[0]);
+        undeployStateless(0);
+        stopServer(0);
+        removeClusterNodes(1, removal);
+        logger.info("Stopped server: " + serverNames[0]);
+
+
+        // invoke
         Thread.sleep(500);
+
+        // start a server and update the topologuy of the new node and the remaining node
+        logger.info("Starting server: " + serverNames[0]);
+        startServer(0);
+        deployStateless(0);
+        defineCluster(0, CLUSTER);
+        addClusterNodes(1, addition);
+        logger.info("Started server: " + serverNames[0]);
+
+        // invoke
+        Thread.sleep(500);
+
         runInvocations = false;
         for(Future<?> i : retList) {
             i.get();
         }
 
-    }
+        // check results
+        System.out.println("map twoNodesUp = " + twoNodesUp.toString());
+        System.out.println("map oneNodeUp = " + oneNodeUp.toString());
 
-    private void undeployAndStopServer(int server) {
-        if (isServerStarted(server)) {
-            try {
-                undeployStateless(server);
-                removeCluster(server, CLUSTER_NAME);
-                stopServer(server);
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            } finally {
-                serversStarted[server] = false;
-            }
-        }
-    }
-
-    private void startServerAndDeploy(int server) throws Exception {
-        startServer(server, 6999 + (server * 100));
-        deployStateless(server);
-        defineCluster(server, CLUSTER);
     }
 
     /**
      * Do any test-specific tear down here.
      */
     @After
-    public void afterTest() {
-        undeployAndStopServer(0);
-        undeployAndStopServer(1);
+    public void afterTest() throws Exception {
+        // shutdown the cluster of two nodes
+        for (int i = 0; i < 2; i++) {
+            stopServer(i);
+            undeployStateless(i);
+            removeCluster(i, CLUSTER.getClusterName());
+        }
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/test/InterruptRunningCallTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/InterruptRunningCallTestCase.java
@@ -12,53 +12,34 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.naming.NamingException;
 
-import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.Echo;
 import org.jboss.ejb.client.test.common.EchoBean;
 import org.jboss.logging.Logger;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.naming.client.WildFlyRootContext;
 import org.wildfly.naming.client.util.FastHashtable;
 
 
-public class InterruptRunningCallTestCase {
+public class InterruptRunningCallTestCase extends AbstractEJBClientTestCase {
     private static final Logger logger = Logger.getLogger(InterruptRunningCallTestCase.class);
 
-    private static final String APP_NAME = "my-foo-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    private static final String SERVER_NAME = "test-server";
-
-    private static DummyServer server;
-
-    @BeforeClass
-    public static void beforeTest() throws Exception {
+    @Before
+    public void beforeTest() throws Exception {
         // start a server
-        server = new DummyServer("localhost", 6999, SERVER_NAME);
-        server.start();
-        logger.info("Started server ...");
-
+        startServer(0);
+        // deploy a custom bean
         String longResponse = generateLongResponse(131072 * 10);
-        server.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(longResponse));
-        logger.info("Registered module ...");
+        deployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getSimpleName(), new EchoBean(longResponse));
     }
 
-    @AfterClass
-    public static void afterTest() {
-        server.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getName());
-        logger.info("Unregistered module ...");
-
-        try {
-            server.stop();
-        } catch (Throwable t) {
-            logger.info("Could not stop server", t);
-        }
-        logger.info("Stopped server ...");
+    @After
+    public void afterTest() {
+        undeployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, EchoBean.class.getName());
+        stopServer(0);
     }
 
     @Test

--- a/src/test/java/org/jboss/ejb/client/test/LearningTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/LearningTestCase.java
@@ -48,32 +48,20 @@ import org.wildfly.naming.client.util.FastHashtable;
 public class LearningTestCase extends AbstractEJBClientTestCase {
     private static final Logger logger = Logger.getLogger(LearningTestCase.class);
 
-    // module
-    private static final String APP_NAME = "my-foo-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    private static final String SERVER_NAME = "test-server";
-
-    private static DummyServer server;
-    private static boolean serverStarted = false;
-
     @Before
     public void beforeTest() throws Exception {
         // start a server
         startServer(0, 6999);
+        // deploy a stateful bean
         deployStateful(0);
         // deploy a different bean
         deployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, FooBean.class.getSimpleName(), new FooBean());
-        logger.info("Registered module ...");
     }
 
     @After
     public void afterTest() {
         undeployStateful(0);
         undeployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, FooBean.class.getName());
-        logger.info("Unregistered module ...");
-
         stopServer(0);
     }
 
@@ -81,27 +69,23 @@ public class LearningTestCase extends AbstractEJBClientTestCase {
         WildFlyRootContext context = new WildFlyRootContext(props);
 
         Object echo = context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + StatefulEchoBean.class.getSimpleName() + "!" + Echo.class.getName() + "?stateful");
-
         Assert.assertEquals(match1, EJBClient.getStrongAffinity(echo));
 
         EJBClient.setStrongAffinity(echo, new ClusterAffinity("test"));
         ((Echo)echo).echo("test");
 
         Object foo = context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + FooBean.class.getSimpleName() + "!" + Foo.class.getName() + "?stateful");
-
         Assert.assertEquals(match2, EJBClient.getStrongAffinity(foo));
     }
 
     private void verifyAffinity(WildFlyRootContext context, Affinity match1, Affinity match2) throws NamingException {
           Object echo = context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + StatefulEchoBean.class.getSimpleName() + "!" + Echo.class.getName() + "?stateful");
-
           Assert.assertEquals(match1, EJBClient.getStrongAffinity(echo));
 
           EJBClient.setStrongAffinity(echo, new ClusterAffinity("test"));
           ((Echo)echo).echo("test");
 
           Object foo = context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + FooBean.class.getSimpleName() + "!" + Foo.class.getName() + "?stateful");
-
           Assert.assertEquals(match2, EJBClient.getStrongAffinity(foo));
       }
 

--- a/src/test/java/org/jboss/ejb/client/test/RemoteDiscoveryTimeoutTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/RemoteDiscoveryTimeoutTestCase.java
@@ -36,19 +36,9 @@ import org.junit.Test;
 /**
  * @author <a href="ingo@redhat.com">Ingo Weiss</a>
  */
-public class RemoteDiscoveryTimeoutTestCase {
+public class RemoteDiscoveryTimeoutTestCase extends AbstractEJBClientTestCase {
    private static final Logger logger = Logger.getLogger(RemoteDiscoveryTimeoutTestCase.class);
    private static final String PROPERTIES_FILE = "no-protocol-jboss-ejb-client.properties";
-
-   private DummyServer server;
-   private boolean serverStarted = false;
-
-   // module
-   private static final String APP_NAME = "my-foo-app";
-   private static final String MODULE_NAME = "my-bar-module";
-   private static final String DISTINCT_NAME = "";
-
-   private static final String SERVER_NAME = "test-server";
 
    /**
     * Do any general setup here
@@ -67,13 +57,9 @@ public class RemoteDiscoveryTimeoutTestCase {
    @Before
    public void beforeTest() throws Exception {
       // start a server
-      server = new DummyServer("localhost", 6999, SERVER_NAME);
-      server.start();
-      serverStarted = true;
-      logger.info("Started server ...");
-
-      server.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getSimpleName(), new EchoBean());
-      logger.info("Registered module ...");
+      startServer(0);
+      // deploy a stateless echo bean
+      deployStateless(0);
    }
 
    /**
@@ -81,17 +67,10 @@ public class RemoteDiscoveryTimeoutTestCase {
     */
    @After
    public void afterTest() {
-      server.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, Echo.class.getName());
-      logger.info("Unregistered module ...");
-
-      if (serverStarted) {
-         try {
-            this.server.stop();
-         } catch (Throwable t) {
-            logger.info("Could not stop server", t);
-         }
-      }
-      logger.info("Stopped server ...");
+      // undeploy a stateless echo bean
+      undeployStateless(0);
+      // stop a server
+      stopServer(0);
    }
 
    /**

--- a/src/test/java/org/jboss/ejb/client/test/SimpleInvocationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/SimpleInvocationTestCase.java
@@ -75,7 +75,7 @@ public class SimpleInvocationTestCase extends AbstractEJBClientTestCase {
     public void beforeTest() throws Exception {
         // start servers
         for (int i = 0; i < 2; i++) {
-            startServer(i, 6999 + (i*100));
+            startServer(i);
             // deploy a stateful bean
             deployStateful(i);
             // deploy a stateless bean

--- a/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/TransactionTestCase.java
@@ -119,7 +119,7 @@ public class TransactionTestCase extends AbstractEJBClientTestCase {
     public void beforeTest() throws Exception {
         // start a server
         for (int i = 0; i < 4; i++) {
-            startServer(i, 6999 + (i*100), true);
+            startServer(i, true);
         }
 
         deployStateless(0);

--- a/src/test/java/org/jboss/ejb/client/test/UnmarshallingFilterTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/UnmarshallingFilterTestCase.java
@@ -30,8 +30,10 @@ import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.ejb.client.test.common.TypeReporter;
 import org.jboss.ejb.client.test.common.TypeReporterBean;
 import org.jboss.logging.Logger;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -40,44 +42,20 @@ import org.junit.Test;
  *
  * @author Brian Stansberry
  */
-public class UnmarshallingFilterTestCase {
+public class UnmarshallingFilterTestCase extends AbstractEJBClientTestCase {
     private static final Logger logger = Logger.getLogger(LearningTestCase.class);
 
-    // module
-    private static final String APP_NAME = "my-foo-app";
-    private static final String MODULE_NAME = "my-bar-module";
-    private static final String DISTINCT_NAME = "";
-
-    private static final String SERVER_NAME = "test-server";
-
-    private static DummyServer server;
-    private static boolean serverStarted = false;
-
-    @BeforeClass
-    public static void beforeTest() throws Exception {
+    @Before
+    public void beforeTest() throws Exception {
         // start a server
-        server = new DummyServer("localhost", 6999, SERVER_NAME);
-        server.start();
-        serverStarted = true;
-        logger.info("Started server ...");
-
-        server.register(APP_NAME, MODULE_NAME, DISTINCT_NAME, TypeReporter.class.getSimpleName(), new TypeReporterBean());
-        logger.info("Registered module ...");
+        startServer(0);
+        deployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, TypeReporter.class.getSimpleName(), new TypeReporterBean());
     }
 
-    @AfterClass
-    public static void afterTest() {
-        server.unregister(APP_NAME, MODULE_NAME, DISTINCT_NAME, TypeReporterBean.class.getName());
-        logger.info("Unregistered module ...");
-
-        if (serverStarted) {
-            try {
-                server.stop();
-            } catch (Throwable t) {
-                logger.info("Could not stop server", t);
-            }
-        }
-        logger.info("Stopped server ...");
+    @After
+    public void afterTest() {
+        undeployCustomBean(0, APP_NAME, MODULE_NAME, DISTINCT_NAME, TypeReporterBean.class.getName());
+        stopServer(0);
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
@@ -343,7 +343,9 @@ public class DummyServer implements AutoCloseable {
     /**
      * Allows keeping track of which clusters this server has joined and their membership.
      *
-     * To keep things simple, this is a direct mapping to the server-side cluster information used.
+     * To keep things simple, this is a direct mapping to the server-side cluster information used; namely,
+     * the classes ClusterInfo, NodeInfo and MappingInfo used by .
+     *
      * The server does not need to store the current state of the clusters.
      */
     public class EJBClusterRegistry {


### PR DESCRIPTION
This PR does the following:
* adjusts some  existing test cases which are not using the AbstractEJBClientTestCase base class to use the primitives defined there for starting/stopping servers and configuring clusters

For more details, see: https://issues.redhat.com/browse/EJBCLIENT-402