### PR TITLE
[master] [EJBCLIENT-406] Adjust capturing of AuthenticationContext after interceptors.

### DIFF
--- a/src/main/java/org/jboss/ejb/_private/Keys.java
+++ b/src/main/java/org/jboss/ejb/_private/Keys.java
@@ -20,10 +20,14 @@ package org.jboss.ejb._private;
 
 import org.jboss.ejb.client.AttachmentKey;
 import org.wildfly.naming.client.NamingProvider;
+import org.wildfly.security.auth.client.AuthenticationContext;
 
 /**
  */
 public final class Keys {
+
+    public static final AttachmentKey<AuthenticationContext> AUTHENTICATION_CONTEXT_ATTACHMENT_KEY = new AttachmentKey<>();
+
     public static final AttachmentKey<NamingProvider> NAMING_PROVIDER_ATTACHMENT_KEY = new AttachmentKey<>();
 
     private Keys() {}

--- a/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
@@ -18,6 +18,8 @@
 
 package org.jboss.ejb.client;
 
+import static org.jboss.ejb._private.Keys.AUTHENTICATION_CONTEXT_ATTACHMENT_KEY;
+
 import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashMap;
@@ -67,7 +69,9 @@ public abstract class AbstractInvocationContext extends Attachable {
     }
 
     public AuthenticationContext getAuthenticationContext() {
-        return authenticationContext;
+        AuthenticationContext attached = getAttachment(AUTHENTICATION_CONTEXT_ATTACHMENT_KEY);
+
+        return attached != null ? attached : authenticationContext;
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/AbstractInvocationContext.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.wildfly.common.Assert;
+import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.transaction.client.AbstractTransaction;
 
 /**
@@ -32,6 +33,7 @@ import org.wildfly.transaction.client.AbstractTransaction;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public abstract class AbstractInvocationContext extends Attachable {
+    private final AuthenticationContext authenticationContext;
     private final EJBClientContext ejbClientContext;
     // selected target receiver
     private EJBReceiver receiver;
@@ -57,9 +59,15 @@ public abstract class AbstractInvocationContext extends Attachable {
     private Map<String, Object> contextData;
     private AbstractTransaction transaction;
 
-    AbstractInvocationContext(final EJBLocator<?> locator, final EJBClientContext ejbClientContext) {
+    AbstractInvocationContext(final EJBLocator<?> locator, final EJBClientContext ejbClientContext,
+            final AuthenticationContext authenticationContext) {
         this.locator = locator;
         this.ejbClientContext = ejbClientContext;
+        this.authenticationContext = authenticationContext;
+    }
+
+    public AuthenticationContext getAuthenticationContext() {
+        return authenticationContext;
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/AuthenticationContextEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/AuthenticationContextEJBClientInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.ejb.client;
+
+import static org.jboss.ejb._private.Keys.AUTHENTICATION_CONTEXT_ATTACHMENT_KEY;
+
+import org.jboss.ejb.client.annotation.ClientInterceptorPriority;
+import org.wildfly.common.function.ExceptionSupplier;
+import org.wildfly.security.auth.client.AuthenticationContext;
+
+/**
+ * EJB client interceptor to capture the {@code AuthenticationContext} after any application interceptors.
+ *
+ * @author <a href="mailto:darran.lofthouse@redhat.com">Darran Lofthouse</a>
+ */
+@ClientInterceptorPriority(AuthenticationContextEJBClientInterceptor.PRIORITY)
+public class AuthenticationContextEJBClientInterceptor implements EJBClientInterceptor {
+
+    public static final int PRIORITY = ClientInterceptorPriority.JBOSS_AFTER + 25;
+
+    @Override
+    public SessionID handleSessionCreation(EJBSessionCreationInvocationContext context) throws Exception {
+        return call(context::proceed, context);
+    }
+
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        call(() -> {
+            context.sendRequest();
+            return null;
+        }, context);
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return call(context::getResult, context);
+    }
+
+    private <T> T call(ExceptionSupplier<T, Exception> action, AbstractInvocationContext context) throws Exception {
+        final AuthenticationContext captured = AuthenticationContext.captureCurrent();
+        final AuthenticationContext previous = context.putAttachment(AUTHENTICATION_CONTEXT_ATTACHMENT_KEY, captured);
+        try {
+            return action.get();
+        } finally {
+            if (previous == null) {
+                context.removeAttachment(AUTHENTICATION_CONTEXT_ATTACHMENT_KEY);
+            } else {
+                context.putAttachment(AUTHENTICATION_CONTEXT_ATTACHMENT_KEY, previous);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -125,6 +125,7 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
 
     static final InterceptorList defaultInterceptors = new InterceptorList(new EJBClientInterceptorInformation[] {
         EJBClientInterceptorInformation.forClass(TransactionInterceptor.class),
+        EJBClientInterceptorInformation.forClass(AuthenticationContextEJBClientInterceptor.class),
         EJBClientInterceptorInformation.forClass(NamingEJBClientInterceptor.class),
         EJBClientInterceptorInformation.forClass(DiscoveryEJBClientInterceptor.class),
         EJBClientInterceptorInformation.forClass(TransactionPostDiscoveryInterceptor.class),

--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -896,7 +896,7 @@ public final class EJBClientContext extends Attachable implements Contextual<EJB
         for (int i = 0; i < MAX_SESSION_RETRIES; i++) {
             Throwable t;
             try {
-                sessionID = context.proceed();
+                sessionID = context.proceedInitial();
                 break;
             } catch (RequestSendFailedException r) {
                 if (! r.canBeRetried()) {

--- a/src/main/java/org/jboss/ejb/client/EJBReceiverSessionCreationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBReceiverSessionCreationContext.java
@@ -27,11 +27,9 @@ import org.wildfly.security.auth.client.AuthenticationContext;
  */
 public final class EJBReceiverSessionCreationContext extends AbstractReceiverInvocationContext {
     private final EJBSessionCreationInvocationContext invocationContext;
-    private final AuthenticationContext authenticationContext;
 
-    EJBReceiverSessionCreationContext(final EJBSessionCreationInvocationContext invocationContext, final AuthenticationContext authenticationContext) {
+    EJBReceiverSessionCreationContext(final EJBSessionCreationInvocationContext invocationContext) {
         this.invocationContext = invocationContext;
-        this.authenticationContext = authenticationContext;
     }
 
     public EJBSessionCreationInvocationContext getClientInvocationContext() {
@@ -39,6 +37,7 @@ public final class EJBReceiverSessionCreationContext extends AbstractReceiverInv
     }
 
     public AuthenticationContext getAuthenticationContext() {
+        AuthenticationContext authenticationContext = invocationContext.getAuthenticationContext();
         return authenticationContext == null ? AuthenticationContext.captureCurrent() : authenticationContext;
     }
 }

--- a/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBSessionCreationInvocationContext.java
@@ -43,6 +43,14 @@ public final class EJBSessionCreationInvocationContext extends AbstractInvocatio
         this.interceptorList = interceptorList;
     }
 
+    SessionID proceedInitial() throws Exception {
+        if (authenticationContext != null) {
+            return authenticationContext.runExFunction(EJBSessionCreationInvocationContext::proceed, this);
+        } else {
+            return proceed();
+        }
+    }
+
     /**
      * Proceed with the next interceptor in the chain, calling the resolved receiver in the end.
      *

--- a/src/test/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptorTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptorTestCase.java
@@ -34,7 +34,7 @@ public class DiscoveryEJBClientInterceptorTestCase {
     public void testBlackList() throws Exception {
         long timeout = 1000L;
         System.setProperty("org.jboss.ejb.client.discovery.blacklist.timeout", timeout + "");
-        AbstractInvocationContext context = new AbstractInvocationContext(null, null) {
+        AbstractInvocationContext context = new AbstractInvocationContext(null, null, null) {
             @Override
             public void requestRetry() {
             }


### PR DESCRIPTION
The AuthenticationContext APIs within Elytron are build around being able to wrap an invocation so the context can be set and cleared automatically around the invocation.  

Client side interceptors should be an ideal place for this kind of wrapping but working with this there were some differences in behaviour regarding how the context was captured and used, this PR contains a sequence of changes to clean up this behaviour and make it consistent.

https://issues.redhat.com/browse/EJBCLIENT-406
