### PR TITLE
EJBCLIENT-429 CI job should set timeout to prevent job hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   build-test-matrix:
     name: ${{ matrix.impl}}-${{ matrix.jdk }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://issues.redhat.com/browse/EJBCLIENT-429