### PR TITLE
[EJBCLIENT-437] At EJBMarhsallingCompatiblityHelper, enable the Proco…

### DIFF
--- a/javax/src/main/java/org/jboss/ejb/protocol/remote/EJBMarshallingCompatibilityHelper.java
+++ b/javax/src/main/java/org/jboss/ejb/protocol/remote/EJBMarshallingCompatibilityHelper.java
@@ -34,11 +34,11 @@ public final class EJBMarshallingCompatibilityHelper implements MarshallingCompa
     public ObjectResolver getObjectResolver(final Transport transport, final boolean request) {
         if (transport instanceof RemoteTransport) {
             final RemoteTransport remoteTransport = (RemoteTransport) transport;
-            if (remoteTransport.getVersion() == 1) {
+            if (remoteTransport.getVersion() == 1) { // this refers to the naming version, not the EJB version
                 // naming version is 1, EJB version is 1 or 2 (same resolver either way)
                 return new ProtocolV1ObjectResolver(remoteTransport.getConnection(), true);
-            } else if (remoteTransport.getVersion() == 2) { // this refers to the naming version, not the EJB version
-                // naming version is 2, EJB version is 3
+            } else {
+                // naming version is 2 or bigger, EJB version is 3
                 return new ProtocolV3ObjectResolver(remoteTransport.getConnection(), true);
             }
         }


### PR DESCRIPTION
…oLV3ObjectResolver for all remote transport version numbers larger than 1

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/EJBCLIENT-437