### PR TITLE
EJBCLIENT-446 Upgrade jakarta.transaction-api from 2.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.org.jboss.narayana>5.12.4.Final</version.org.jboss.narayana>
         <version.org.jboss.remoting>5.0.23.Final</version.org.jboss.remoting>
         <version.jakarta.ejb-api>4.0.1</version.jakarta.ejb-api>
-        <version.jakarta-transaction-api>2.0.0</version.jakarta-transaction-api>
+        <version.jakarta-transaction-api>2.0.1</version.jakarta-transaction-api>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.8.2.Final</version.org.jboss.xnio>


### PR DESCRIPTION
https://issues.redhat.com/browse/EJBCLIENT-446