### PR TITLE
[EJBCLIENT-458] Restore exception handling semantics prior to EJBCLIE…

### DIFF
--- a/src/main/java/org/jboss/ejb/client/ConfigurationBasedEJBClientContextSelector.java
+++ b/src/main/java/org/jboss/ejb/client/ConfigurationBasedEJBClientContextSelector.java
@@ -247,9 +247,7 @@ final class ConfigurationBasedEJBClientContextSelector {
         ClassLoader cl;
         if (moduleName != null) {
             try {
-                cl = Module.getModuleFromCallerModuleLoader(moduleName).getClassLoader();
-            } catch (ModuleLoadException e) {
-                throw new ConfigXMLParseException(e);
+                cl = ModuleLoadDelegate.loadModule(moduleName);
             } catch (LinkageError e) {
                 throw Logs.MAIN.noJBossModules(streamReader);
             }
@@ -269,6 +267,16 @@ final class ConfigurationBasedEJBClientContextSelector {
             return clazz;
         }
         throw streamReader.unexpectedElement();
+    }
+
+    static final class ModuleLoadDelegate {
+        static ClassLoader loadModule(String moduleName) throws ConfigXMLParseException {
+            try {
+                return Module.getModuleFromCallerModuleLoader(moduleName).getClassLoader();
+            } catch (ModuleLoadException e) {
+                throw new ConfigXMLParseException(e);
+            }
+        }
     }
 
     private static void parseConnectionsType(final ConfigurationXMLStreamReader streamReader, final EJBClientContext.Builder builder) throws ConfigXMLParseException {


### PR DESCRIPTION
…NT-417 (#575)

Issue: https://issues.redhat.com/browse/JBEAP-24148
Upstream issue: https://issues.redhat.com/browse/EJBCLIENT-458
Upstream PR: https://github.com/wildfly/jboss-ejb-client/pull/575