### PR TITLE
EJBCLIENT-466 parent.relativePath points to the wrong parent pom (#582)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
         <version>39</version>
+        <relativePath/>
     </parent>
 
     <artifactId>jboss-ejb-client</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/EJBCLIENT-466