### PR TITLE
EJBCLIENT-486 Upgrade xnio to 3.8.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <version.jakarta-transaction-api>2.0.1</version.jakarta-transaction-api>
         <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
         <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.8.2.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.8.8.Final</version.org.jboss.xnio>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
         <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>


### PR DESCRIPTION
https://issues.redhat.com/browse/EJBCLIENT-486

this is port of https://github.com/wildfly/jboss-ejb-client/pull/601 from 4.x branch to main branch.