### PR TITLE
[EJBCLIENT-493] Fix verbose DISCOVERY_ADDITIONAL_TIMEOUT logging duri…

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -543,7 +543,9 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
                     //one has already been discovered, we may want a shorter timeout for additional nodes
                     if (DISCOVERY_ADDITIONAL_TIMEOUT != 0) {
                         timeout = DISCOVERY_ADDITIONAL_TIMEOUT; //this one is actually in ms, you generally want it very short
-                        Logs.MAIN.warnf("  DISCOVERY_ADDITIONAL_TIMEOUT = %s", timeout);
+                        if (Logs.INVOCATION.isDebugEnabled()) {
+                            Logs.INVOCATION.debugf("  DISCOVERY_ADDITIONAL_TIMEOUT = %s", timeout);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…ng EJB discovery.

(cherry picked from commit ce7421be5567f0514c49dc7df7407e70fe59576b)

Issue: https://issues.redhat.com/browse/EJBCLIENT-493

JBEAP issue: https://issues.redhat.com/browse/JBEAP-24818

main branch PR: https://github.com/wildfly/jboss-ejb-client/pull/611