### PR TITLE
Add better TRACE-level debugging for EJBClientInvocationContext state machine

### DIFF
--- a/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/DiscoveryEJBClientInterceptor.java
@@ -256,6 +256,11 @@ public final class DiscoveryEJBClientInterceptor implements EJBClientInterceptor
     private void processMissingTarget(final AbstractInvocationContext context, final Exception cause) {
         final URI destination = context.getDestination();
 
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            String message = cause != null ? cause.getMessage() : "null";
+            Logs.INVOCATION.debugf("DiscoveryEJBClientInterceptor: processing missing target for locator %s (exception = %s), *** retrying ***", context.getLocator(), message);
+        }
+
         if (destination == null || context.getTargetAffinity() == Affinity.LOCAL) {
             // nothing we can/should do.
             return;

--- a/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/NamingEJBClientInterceptor.java
@@ -210,13 +210,15 @@ public final class NamingEJBClientInterceptor implements EJBClientInterceptor {
 
     private void processMissingTarget(final AbstractInvocationContext context, Exception cause) {
         final URI destination = context.getDestination();
+
+        if (Logs.INVOCATION.isDebugEnabled()) {
+            String message = cause != null ? cause.getMessage() : "null";
+            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: processing missing target for locator %s, exception = %s, *** retrying ***", context.getLocator(), cause);
+        }
+
         if (destination == null || context.getTargetAffinity() == Affinity.LOCAL) {
             // some later interceptor cleared it out on us
             return;
-        }
-
-        if (Logs.INVOCATION.isDebugEnabled()) {
-            Logs.INVOCATION.debugf("NamingEJBClientInterceptor: missing target, *** retrying ***: locator = %s", context.getLocator());
         }
 
         // Oops, we got some wrong information!


### PR DESCRIPTION
This is a draft pull request to add better trace level logging to EJBCientInvocationContext state machine.
